### PR TITLE
Fix XML documentation issues flagged in review

### DIFF
--- a/tools/cli/Commands/PdkCommandModule.cs
+++ b/tools/cli/Commands/PdkCommandModule.cs
@@ -877,12 +877,14 @@ internal sealed class PdkCommandModule : ICommandModule
     }
 
     /// <summary>
-        /// Split a comma-separated string into trimmed, non-empty tokens.
-        /// </summary>
-        /// <param name="value">The comma-separated input string to split.</param>
-        /// <returns>A list of trimmed tokens; an empty list if <paramref name="value"/> is null, empty, or consists only of whitespace.</returns>
-        private static List<string> SplitCsv(string value)
-        => string.IsNullOrWhiteSpace(value) ? new List<string>() : value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
+    /// Split a comma-separated string into trimmed, non-empty tokens.
+    /// </summary>
+    /// <param name="value">The comma-separated input string to split.</param>
+    /// <returns>A list of trimmed tokens; an empty list if <paramref name="value"/> is null, empty, or consists only of whitespace.</returns>
+    private static List<string> SplitCsv(string value)
+        => string.IsNullOrWhiteSpace(value)
+            ? new List<string>()
+            : value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
 
     /// <summary>
     /// Generate a testbench and supporting files for the specified Spectre model and place them in the given job directory.

--- a/tools/workspace/ModelContext.cs
+++ b/tools/workspace/ModelContext.cs
@@ -24,11 +24,11 @@ public sealed class ModelContext : IEquatable<ModelContext>
     }
 
     /// <summary>
-/// Determines whether the specified object is equal to the current ModelContext instance.
-/// </summary>
-/// <param name="obj">The object to compare with the current instance.</param>
-/// <returns>`true` if <paramref name="obj"/> is a ModelContext whose values match this instance; `false` otherwise.</returns>
-public override bool Equals(object? obj) => Equals(obj as ModelContext);
+    /// Determines whether the specified object is equal to the current <see cref="ModelContext"/> instance.
+    /// </summary>
+    /// <param name="obj">The object to compare with the current instance.</param>
+    /// <returns>`true` if <paramref name="obj"/> is a <see cref="ModelContext"/> whose values match this instance; `false` otherwise.</returns>
+    public override bool Equals(object? obj) => Equals(obj as ModelContext);
 
     /// <summary>
     /// Computes a hash code that represents this ModelContext's value identity.

--- a/tools/workspace/PdkDatabase.cs
+++ b/tools/workspace/PdkDatabase.cs
@@ -57,19 +57,13 @@ public sealed class PdkDatabase : IDisposable
     }
 
     /// <summary>
-    /// Ensures the database schema exists by creating all required tables and constraints if they are missing.
-    /// </summary>
-    /// <remarks>
-    /// Executes the DDL statements inside a transaction so the schema creation is applied atomically.
-    /// This method is idempotent and safe to call on an existing schema.
-    /// <summary>
     /// Ensures the database schema exists and is migrated to the expected layout for the PDK.
     /// </summary>
     /// <remarks>
     /// Executes a series of idempotent DDL statements inside a single transaction to create tables,
     /// keys, unique constraints and foreign-key relationships required by the application.
     /// Calling this method multiple times is safe; it uses IF NOT EXISTS to avoid redeclaring objects
-    /// and commits atomically only after all statements succeed.
+    /// and commits atomically only after all statements succeed, preserving atomic schema updates.
     /// </remarks>
     private void CreateSchema()
     {

--- a/tools/workspace/PdkDatabaseReader.cs
+++ b/tools/workspace/PdkDatabaseReader.cs
@@ -149,8 +149,6 @@ public static class PdkDatabaseReader
 
         return models.Select(m => m.Model).ToArray();
     }
-
-    // Efficient, server-side filtered device listing for TUI screens.
     /// <summary>
     /// Load a paginated list of devices with aggregated view names, optionally filtered by device class.
     /// </summary>
@@ -204,8 +202,6 @@ public static class PdkDatabaseReader
         }
         return list;
     }
-
-    // Return include candidates (deck paths) for a model, ordered by preference.
     /// <summary>
     /// Get the include/deck file paths associated with a model, ordered by preference.
     /// </summary>

--- a/tools/workspace/PdkDatabaseWriter.cs
+++ b/tools/workspace/PdkDatabaseWriter.cs
@@ -124,11 +124,9 @@ public static class PdkDatabaseWriter
     }
 
     /// <summary>
-    /// Compute and store per-class rollups so the CLI can render instantly.
-    /// <summary>
-    /// Recomputes and persists per-device-class rollup metrics into the database's device_class_summary table.
+    /// Recomputes and persists per-device-class rollup metrics into the database's <c>device_class_summary</c> table.
     /// </summary>
-    /// <param name="dbPath">Filesystem path to the SQLite database file to update; existing device_class_summary rows are replaced or updated.</param>
+    /// <param name="dbPath">Filesystem path to the SQLite database file to update; existing summary rows are replaced or updated.</param>
     public static void RebuildDeviceClassSummary(string dbPath)
     {
         using var db = PdkDatabase.Open(dbPath);
@@ -472,12 +470,11 @@ public static class PdkDatabaseWriter
     }
 
     /// <summary>
-    /// Upserts device rows into the devices table and inserts associated device_views rows for each device.
+    /// Upserts device rows into the devices table and ensures each device's view entries exist in <c>device_views</c>.
     /// </summary>
-    /// <summary>
-    /// Upserts device rows into the devices table and ensures each device's view entries exist in device_views.
-    /// </summary>
-    /// <param name="devices">Devices to persist; each device's canonical name is used as the key and the device's properties (including vt/vdd/tag values and layout/symbol flags) are written or updated and its view entries are inserted into device_views.</param>
+    /// <param name="conn">Open SQLite connection used to persist device metadata.</param>
+    /// <param name="tx">Active transaction that scopes the upsert operations.</param>
+    /// <param name="devices">Devices to persist; each device's canonical name is used as the key and the device's properties (including vt/vdd/tag values and layout/symbol flags) are written or updated and its view entries are inserted into <c>device_views</c>.</param>
     private static void UpsertDevices(SqliteConnection conn, SqliteTransaction tx, IReadOnlyList<Device> devices)
     {
         using var insertDevice = conn.CreateCommand();


### PR DESCRIPTION
## Summary
- consolidate duplicated XML documentation blocks and fix indentation issues flagged in review feedback
- add missing parameter descriptions for workspace database helpers and clean up redundant inline comments

## Testing
- `dotnet format --verbosity diagnostic`


------
https://chatgpt.com/codex/tasks/task_e_68ec94c5d75083228e5a717304896bad