### PR TITLE
Add README for CLI tool packaging

### DIFF
--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -1,0 +1,5 @@
+# Cascode CLI
+
+Cascode CLI is the command-line interface for the Cascode project, enabling users to synthesize, verify, and run Cascode ADL flows from the terminal.
+
+For general project information, see the [top-level README](../../README.md).


### PR DESCRIPTION
## Summary
- add a README file for the Cascode CLI tool so `dotnet pack` can include it

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ede811b7b083228112fb11aee93131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a README for the Cascode CLI that introduces its purpose and capabilities.
  * Describes how the CLI enables synthesizing, verifying, and running Cascode ADL flows directly from the terminal.
  * Provides guidance on where to find broader project information via a link to the main README.
  * Helps new users quickly understand the CLI’s scope and how to get started.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->