### PR TITLE
Chore (release): bump to v0.2.0, centralize release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,55 @@ permissions:
   contents: write
 
 jobs:
+  version-check:
+    name: verify versions match tag
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: verify repo versions match tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME#v}"
+          echo "Tag version: $TAG"
+
+          # Verify npm wrapper version matches tag
+          NPM_VER="$(python3 - <<'PY'
+import json
+with open('tools/npm/cascode-cli/package.json', 'r', encoding='utf-8') as f:
+    print(json.load(f)['version'])
+PY
+)"
+          echo "npm version: $NPM_VER"
+          if [[ "$NPM_VER" != "$TAG" ]]; then
+            echo "ERROR: tools/npm/cascode-cli/package.json version ($NPM_VER) does not match tag ($TAG)" >&2
+            exit 1
+          fi
+
+          # Verify Directory.Build.props CascodeVersion matches tag
+          PROPS_VER="$(python3 - <<'PY'
+import xml.etree.ElementTree as ET
+root = ET.parse('Directory.Build.props').getroot()
+ns = {'msb': root.tag.split('}')[0].strip('{')} if root.tag.startswith('{') else {}
+def find_text(tag):
+    if ns:
+        el = root.find(f".//msb:{tag}", ns)
+    else:
+        el = root.find(f".//{tag}")
+    return (el.text or '').strip() if el is not None else ''
+print(find_text('CascodeVersion'))
+PY
+)"
+          echo "CascodeVersion: $PROPS_VER"
+          if [[ "$PROPS_VER" != "$TAG" ]]; then
+            echo "ERROR: Directory.Build.props CascodeVersion ($PROPS_VER) does not match tag ($TAG)" >&2
+            exit 1
+          fi
+
   build:
     name: build ${{ matrix.rid }}
     runs-on: ${{ matrix.os }}
+    needs: version-check
     strategy:
       fail-fast: false
       matrix:
@@ -33,9 +79,13 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
+      - name: set version from tag
+        shell: bash
+        run: |
+          echo "TAG=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
       - name: publish
         run: |
-          dotnet publish tools/cli/Cascode.Cli.csproj -c Release -r ${{ matrix.rid }} -p:PublishSingleFile=true -p:SelfContained=true -p:PublishTrimmed=false -o build/out/${{ matrix.rid }}
+          dotnet publish tools/cli/Cascode.Cli.csproj -c Release -r ${{ matrix.rid }} -p:Version=${{ env.TAG }} -p:PublishSingleFile=true -p:SelfContained=true -p:PublishTrimmed=false -o build/out/${{ matrix.rid }}
       - name: normalize binary name (unix)
         if: startsWith(matrix.rid, 'linux-') || startsWith(matrix.rid, 'osx-')
         shell: bash
@@ -127,7 +177,7 @@ jobs:
       - name: set version from tag
         run: |
           TAG=${GITHUB_REF_NAME#v}
-          dotnet pack tools/cli/Cascode.Cli.csproj -c Release -p:PackageVersion=$TAG -o build/nuget
+          dotnet pack tools/cli/Cascode.Cli.csproj -c Release -p:Version=$TAG -p:PackageVersion=$TAG -o build/nuget
       - name: publish to nuget
         run: dotnet nuget push build/nuget/*.nupkg --source https://api.nuget.org/v3/index.json --skip-duplicate --api-key $NUGET_API_KEY
         env:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,13 @@
   <!-- Enable NuGet lock files repo-wide so CI can cache deterministically -->
   <PropertyGroup>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
+    <!--
+      Default version for local/dev builds.
+      Release CI overrides this from the git tag (see .github/workflows/release.yml).
+    -->
+    <CascodeVersion>0.2.0</CascodeVersion>
+    <Version>$(CascodeVersion)</Version>
+    <PackageVersion>$(CascodeVersion)</PackageVersion>
   </PropertyGroup>
 
   <!-- Apply stricter settings only to projects under tools/* -->

--- a/README.md
+++ b/README.md
@@ -451,4 +451,4 @@ Highlights keywords (`module`, `slot`, `synth`, `spec`), typed units (`1.8V`, `1
 
 ## 📄 License
 
-BSD-3
+BSD-3-Clause

--- a/tools/cli/Cascode.Cli.csproj
+++ b/tools/cli/Cascode.Cli.csproj
@@ -15,7 +15,7 @@
     <RepositoryUrl>https://github.com/daniellovell/cascode</RepositoryUrl>
     <PackageProjectUrl>https://github.com/daniellovell/cascode</PackageProjectUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <Version>0.1.0</Version>
+    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/cli/Commands/SystemCommandModule.cs
+++ b/tools/cli/Commands/SystemCommandModule.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Reflection;
 
 namespace Cascode.Cli.Commands;
 
@@ -66,7 +67,11 @@ internal sealed class SystemCommandModule : ICommandModule
 
     private CommandResult ShowVersion(string[] args)
     {
-        var version = typeof(SystemCommandModule).Assembly.GetName().Version?.ToString() ?? "0.0.0";
+        var asm = typeof(SystemCommandModule).Assembly;
+        var info = asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion;
+        var version = string.IsNullOrWhiteSpace(info)
+            ? (asm.GetName().Version?.ToString() ?? "0.0.0")
+            : info.Split('+', 2)[0]; // strip build metadata if present
         _state.AddMessage(version);
         return CommandResult.Success;
     }

--- a/tools/npm/cascode-cli/package.json
+++ b/tools/npm/cascode-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cascode/cascode-cli",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Cascode CLI installer wrapper. Installs a prebuilt cascode binary for your platform.",
   "homepage": "https://github.com/daniellovell/cascode",
   "repository": {
@@ -10,7 +10,7 @@
   "bugs": {
     "url": "https://github.com/daniellovell/cascode/issues"
   },
-  "license": "UNLICENSED",
+  "license": "BSD-3-Clause",
   "private": false,
   "bin": {
     "cascode": "bin/cascode.js"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cascode CLI version updated to 0.2.0
  * License updated to BSD-3-Clause for improved clarity
  * Enhanced version display mechanism for consistency across packages

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->