### PR TITLE
 [acir] add HierarchyValidator for multi-circuit validation 

### DIFF
--- a/spec/language/Ch03_ACIR.md
+++ b/spec/language/Ch03_ACIR.md
@@ -1123,11 +1123,15 @@ The ACIR reader emits structured diagnostics when parsing fails or encounters ma
 | ACIR0005 | Warning | Malformed binding syntax; expects `TERMINAL->NET` |
 | ACIR0006 | Error | Invalid sweep range specification; expects `[start:stop]` or `[start:step:stop]` |
 | ACIR0007 | Error | ACIR major version mismatch; reader rejects different major versions |
+| ACIR0008 | Error | Invalid level declaration; expects `HL`, `ML`, or `EL` |
+| ACIR0009 | Error | JSON parse error when reading ACIR from JSON format |
 | ACIR0010 | Error | Parallel load specification missing parentheses; expects `(C=... \|\| R=...)` |
 | ACIR0011 | Error | Parallel load specification missing `\|\|` operator between elements |
 | ACIR0012 | Error | Parallel load specification missing first element (before `\|\|`) |
 | ACIR0013 | Error | Parallel load specification missing second element (after `\|\|`) |
 | ACIR0014 | Error | Parallel load element missing value; expects `C=<value>` or `R=<value>` |
+| ACIR0015 | Error | Invalid instance declaration syntax |
+| ACIR0016 | Error | Invalid attach statement syntax; includes malformed attach, unterminated override block, or invalid override syntax |
 
 ### Semantic Validation Codes
 
@@ -1141,6 +1145,8 @@ The following codes apply during semantic analysis, particularly attach resoluti
 | ACIR0023 | Error | Conflicting binding; cannot unify nets already bound to different named nets |
 | ACIR0024 | Error | Domain mismatch between terminals being connected |
 | ACIR0025 | Error | Cannot auto-create supply/ground net; bind rails explicitly |
+| ACIR0026 | Warning | Source trait not found in trait registry; using default domain for port domain resolution |
+| ACIR0027 | Warning | Target trait not found in trait registry; using default domain for port domain resolution |
 
 ### Programmatic Access
 

--- a/tests/golden/acir/hierarchy/CurrentMirror_Standalone.el.cir
+++ b/tests/golden/acir/hierarchy/CurrentMirror_Standalone.el.cir
@@ -1,0 +1,24 @@
+ACIR 2.0
+
+trait CurrentMirrorTrait:
+  port IN : analog
+  port OUT : analog
+  connectors:
+    to LoadBranch:
+      OUT -> IN
+
+circuit CurrentMirror : CurrentMirrorTrait
+  level EL
+  param ratio : real = 1
+  param W : real = 2u
+  param L : real = 180n
+  supply VDD
+  ground GND
+  port IN : analog
+  port OUT : analog
+  fill:
+    pmos M_SENSE (B->VDD, D->IN, G->IN, S->VDD) : L=$L M=1 W=$W pmos
+    pmos M_TAP0 (B->VDD, D->OUT, G->IN, S->VDD) : L=$L M=$ratio W=$W pmos
+  constraints:
+    tech:
+      t_lmin : L >= 180n m on *

--- a/tests/golden/acir/hierarchy/OTA5T_Hierarchical.el.cir
+++ b/tests/golden/acir/hierarchy/OTA5T_Hierarchical.el.cir
@@ -1,0 +1,91 @@
+ACIR 2.0
+
+trait CurrentMirrorTrait:
+  port IN : analog
+  port OUT : analog
+  connectors:
+    to LoadBranch:
+      OUT -> IN
+
+trait LoadBranch:
+  port IN : analog
+
+trait DiffPairTrait:
+  port IN_P : analog
+  port IN_N : analog
+  port OUT_P : analog
+  port OUT_N : analog
+  port TAIL : analog
+
+circuit DiffPair : DiffPairTrait
+  level EL
+  inline
+  param W : real = 2u
+  param L : real = 180n
+  supply VDD
+  ground GND
+  port IN_P : analog
+  port IN_N : analog
+  port OUT_P : analog
+  port OUT_N : analog
+  port TAIL : analog
+  fill:
+    net tnode : analog
+    nmos M_N (B->GND, D->OUT_P, G->IN_P, S->tnode) : L=$L M=1 W=$W nmos
+    nmos M_P (B->GND, D->OUT_N, G->IN_N, S->tnode) : L=$L M=1 W=$W nmos
+    nmos M_TAIL (B->GND, D->tnode, G->TAIL, S->GND) : L=$L M=1 W=4u nmos
+
+circuit ActiveLoad : LoadBranch
+  level EL
+  inline
+  param W : real = 2u
+  param L : real = 180n
+  supply VDD
+  ground GND
+  port IN : analog
+  fill:
+    pmos M_LOAD (B->VDD, D->IN, G->IN, S->VDD) : L=$L M=1 W=$W pmos
+
+circuit OTA5T_Hierarchical
+  level EL
+  supply VDD
+  ground GND
+  port IN_P : analog
+  port IN_N : analog
+  port OUT : analog
+  port VTAIL : bias
+  fill:
+    inst dp (IN_P->IN_P, IN_N->IN_N, OUT_P->mirror_gate, OUT_N->OUT, TAIL->VTAIL, VDD->VDD, GND->GND) : DiffPair
+      param W = 2u
+      param L = 180n
+    inst cm (IN->mirror_gate, OUT->OUT, VDD->VDD, GND->GND) : CurrentMirror
+      param ratio = 1
+    inst load (IN->mirror_gate, VDD->VDD, GND->GND) : ActiveLoad
+  constraints:
+    numeric:
+      c_gbw : GainBandwidth @ OUT >= 20M Hz
+      c_gain : PassbandGain @ OUT >= 40 dB
+      c_pm : PhaseMargin @ OUT >= 60 deg
+    measure:
+      m_gbw : SEOpAmpACBench GainBandwidth @ OUT
+      m_gain : SEOpAmpACBench PassbandGain @ OUT
+      m_pm : SEOpAmpACBench PhaseMargin @ OUT
+  harness:
+    supply VDD = 1.8V
+    bias VTAIL = 0.6V
+    load OUT C=1pF
+  benches:
+    SEOpAmpACBench
+
+circuit CurrentMirror : CurrentMirrorTrait
+  level EL
+  param ratio : real = 1
+  param W : real = 2u
+  param L : real = 180n
+  supply VDD
+  ground GND
+  port IN : analog
+  port OUT : analog
+  fill:
+    pmos M_SENSE (B->VDD, D->IN, G->IN, S->VDD) : L=$L M=1 W=$W pmos
+    pmos M_TAP0 (B->VDD, D->OUT, G->IN, S->VDD) : L=$L M=$ratio W=$W pmos

--- a/tests/unit/tools/acir/Cascode.ACIR.Tests/ACIRReaderBasicTests.cs
+++ b/tests/unit/tools/acir/Cascode.ACIR.Tests/ACIRReaderBasicTests.cs
@@ -202,6 +202,30 @@ circuit TestCircuit
     }
 
     [Fact]
+    public void TryParse_InvalidLevel_EmitsACIR0008()
+    {
+        var acir =
+            $@"ACIR {ACIRVersion.Current}
+
+circuit Test
+  level XL
+  supply VDD
+  ground GND
+";
+
+        var result = ACIRReader.TryParse(acir, "test.cir");
+
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            d =>
+                d.Severity == DiagnosticSeverity.Error
+                && d.Message.Contains("ACIR0008")
+                && d.Message.Contains("XL")
+        );
+    }
+
+    [Fact]
     public void ACIRReadResult_ErrorCount_ReflectsErrors()
     {
         var acir =
@@ -243,4 +267,179 @@ circuit TestCircuit
         Assert.True(result.HasWarnings);
         Assert.True(result.WarningCount >= 2);
     }
+
+    #region Attach Override Parsing
+
+    [Fact]
+    public void TryRead_AttachWithInlineOverrides_ParsesOverrides()
+    {
+        var acir =
+            $@"ACIR {ACIRVersion.Current}
+
+trait CurrentMirrorLike:
+  port SENSE : analog
+  connectors:
+    to DiffPairLike:
+      SENSE -> OUT.P
+
+trait DiffPairLike:
+  port OUT.P : analog
+  port OUT.N : analog
+
+circuit Test
+  level EL
+  supply VDD
+  ground GND
+  fill:
+    attach cm to dp via CurrentMirrorLike::DiffPairLike {{
+      SENSE -> OUT.N
+    }}
+";
+
+        using var reader = new StringReader(acir);
+        var result = ACIRReader.TryRead(reader, "test.cir");
+
+        Assert.True(
+            result.Success,
+            $"Parse failed: {string.Join(", ", result.Diagnostics.Select(d => d.Message))}"
+        );
+        Assert.NotNull(result.Document);
+
+        var circuit = result.Document!.Circuits.First();
+        Assert.NotNull(circuit.Fill);
+        Assert.Single(circuit.Fill!.Attaches);
+
+        var attach = circuit.Fill.Attaches[0];
+        Assert.NotNull(attach.Overrides);
+        Assert.Single(attach.Overrides);
+        Assert.Equal("SENSE", attach.Overrides[0].SourcePort);
+        Assert.Equal("OUT.N", attach.Overrides[0].TargetPort);
+    }
+
+    [Fact]
+    public void TryRead_AttachWithAnchorAndOverrides_ParsesBoth()
+    {
+        var acir =
+            $@"ACIR {ACIRVersion.Current}
+
+trait CurrentMirrorLike:
+  port SENSE : analog
+  connectors:
+    to DiffPairLike:
+      SENSE -> OUT.P
+
+trait DiffPairLike:
+  port OUT.P : analog
+  port OUT.N : analog
+
+circuit Test
+  level EL
+  supply VDD
+  ground GND
+  fill:
+    attach cm to dp via CurrentMirrorLike::DiffPairLike as mirror_node {{
+      SENSE -> OUT.N
+    }}
+";
+
+        using var reader = new StringReader(acir);
+        var result = ACIRReader.TryRead(reader, "test.cir");
+
+        Assert.True(
+            result.Success,
+            $"Parse failed: {string.Join(", ", result.Diagnostics.Select(d => d.Message))}"
+        );
+        Assert.NotNull(result.Document);
+
+        var circuit = result.Document!.Circuits.First();
+        var attach = circuit.Fill!.Attaches[0];
+
+        Assert.Equal("mirror_node", attach.Anchor);
+        Assert.NotNull(attach.Overrides);
+        Assert.Single(attach.Overrides);
+        Assert.Equal("SENSE", attach.Overrides[0].SourcePort);
+        Assert.Equal("OUT.N", attach.Overrides[0].TargetPort);
+    }
+
+    [Fact]
+    public void TryRead_AttachWithMultipleOverrides_ParsesAll()
+    {
+        var acir =
+            $@"ACIR {ACIRVersion.Current}
+
+trait CurrentMirrorLike:
+  port SENSE : analog
+  port TAP : analog
+  connectors:
+    to DiffPairLike:
+      SENSE -> OUT.P
+      TAP -> OUT.N
+
+trait DiffPairLike:
+  port OUT.P : analog
+  port OUT.N : analog
+
+circuit Test
+  level EL
+  supply VDD
+  ground GND
+  fill:
+    attach cm to dp via CurrentMirrorLike::DiffPairLike {{
+      SENSE -> OUT.N
+      TAP -> OUT.P
+    }}
+";
+
+        using var reader = new StringReader(acir);
+        var result = ACIRReader.TryRead(reader, "test.cir");
+
+        Assert.True(
+            result.Success,
+            $"Parse failed: {string.Join(", ", result.Diagnostics.Select(d => d.Message))}"
+        );
+        Assert.NotNull(result.Document);
+
+        var circuit = result.Document!.Circuits.First();
+        var attach = circuit.Fill!.Attaches[0];
+
+        Assert.NotNull(attach.Overrides);
+        Assert.Equal(2, attach.Overrides.Count);
+    }
+
+    [Fact]
+    public void TryRead_AttachWithoutOverrides_HasNullOverrides()
+    {
+        var acir =
+            $@"ACIR {ACIRVersion.Current}
+
+trait CurrentMirrorLike:
+  port SENSE : analog
+  connectors:
+    to DiffPairLike:
+      SENSE -> OUT.P
+
+trait DiffPairLike:
+  port OUT.P : analog
+
+circuit Test
+  level EL
+  supply VDD
+  ground GND
+  fill:
+    attach cm to dp via CurrentMirrorLike::DiffPairLike
+";
+
+        using var reader = new StringReader(acir);
+        var result = ACIRReader.TryRead(reader, "test.cir");
+
+        Assert.True(result.Success);
+        Assert.NotNull(result.Document);
+
+        var circuit = result.Document!.Circuits.First();
+        var attach = circuit.Fill!.Attaches[0];
+
+        Assert.Null(attach.Overrides);
+    }
+
+    #endregion
 }

--- a/tests/unit/tools/acir/Cascode.ACIR.Tests/ACIRReaderHierarchyTests.cs
+++ b/tests/unit/tools/acir/Cascode.ACIR.Tests/ACIRReaderHierarchyTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 using Cascode.ACIR;
 using Cascode.Parser;
 
@@ -244,7 +245,7 @@ circuit TestCircuit
         Assert.Single(result.Document.Circuits[0].Fill!.Attaches);
         var attach = result.Document.Circuits[0].Fill!.Attaches[0];
         Assert.Equal("cm1", attach.SourceInstance);
-        Assert.Equal("load1", attach.TargetInstance);
+        Assert.Equal("load1", attach.TargetInstances.Single());
         Assert.Equal("CurrentMirror::LoadBranch", attach.Via);
         Assert.Null(attach.Anchor);
     }
@@ -269,6 +270,154 @@ circuit TestCircuit
         Assert.NotNull(result.Document);
         var attach = result.Document!.Circuits[0].Fill!.Attaches[0];
         Assert.Equal("bias_net", attach.Anchor);
+    }
+
+    [Fact]
+    public void TryRead_AttachWithInlineOverrides_ParsesSuccessfully()
+    {
+        var acir =
+            $@"ACIR {ACIRVersion.Current}
+
+circuit TestCircuit
+  level EL
+  supply VDD
+  ground GND
+  fill:
+    attach cm1 to load1 via CurrentMirror::LoadBranch {{ SENSE -> OUT.N }}
+";
+
+        var result = ACIRReader.TryParse(acir, "test.cir");
+
+        Assert.True(result.Success);
+        var attach = result.Document!.Circuits[0].Fill!.Attaches[0];
+        Assert.NotNull(attach.Overrides);
+        Assert.Single(attach.Overrides!);
+        Assert.Equal("SENSE", attach.Overrides![0].SourcePort);
+        Assert.Equal("OUT.N", attach.Overrides![0].TargetPort);
+    }
+
+    [Fact]
+    public void TryRead_AttachWithMultilineOverrides_ParsesSuccessfully()
+    {
+        var acir =
+            $@"ACIR {ACIRVersion.Current}
+
+circuit TestCircuit
+  level EL
+  supply VDD
+  ground GND
+  fill:
+    attach cm1 to load1 via CurrentMirror::LoadBranch {{
+      SENSE -> OUT.N
+      OUT -> IN
+    }}
+";
+
+        var result = ACIRReader.TryParse(acir, "test.cir");
+
+        Assert.True(result.Success);
+        var attach = result.Document!.Circuits[0].Fill!.Attaches[0];
+        Assert.NotNull(attach.Overrides);
+        Assert.Equal(2, attach.Overrides!.Count);
+        Assert.Equal("SENSE", attach.Overrides![0].SourcePort);
+        Assert.Equal("OUT.N", attach.Overrides![0].TargetPort);
+        Assert.Equal("OUT", attach.Overrides![1].SourcePort);
+        Assert.Equal("IN", attach.Overrides![1].TargetPort);
+    }
+
+    [Fact]
+    public void TryRead_AttachChain_ParsesSuccessfully()
+    {
+        var acir =
+            $@"ACIR {ACIRVersion.Current}
+
+circuit TestCircuit
+  level EL
+  supply VDD
+  ground GND
+  fill:
+    attach a to b to c via CurrentMirror::LoadBranch
+";
+
+        var result = ACIRReader.TryParse(acir, "test.cir");
+
+        Assert.True(result.Success);
+        var attach = result.Document!.Circuits[0].Fill!.Attaches[0];
+        Assert.Equal("a", attach.SourceInstance);
+        Assert.Equal(new[] { "b", "c" }, attach.TargetInstances);
+    }
+
+    [Fact]
+    public void TryRead_AttachChainWithAnchor_ParsesSuccessfully()
+    {
+        var acir =
+            $@"ACIR {ACIRVersion.Current}
+
+circuit TestCircuit
+  level EL
+  supply VDD
+  ground GND
+  fill:
+    attach a to b to c via CurrentMirror::LoadBranch as bias_net
+";
+
+        var result = ACIRReader.TryParse(acir, "test.cir");
+
+        Assert.True(result.Success);
+        var attach = result.Document!.Circuits[0].Fill!.Attaches[0];
+        Assert.Equal("bias_net", attach.Anchor);
+        Assert.Equal(new[] { "b", "c" }, attach.TargetInstances);
+    }
+
+    [Fact]
+    public void TryRead_AttachChainWithOverrides_ParsesSuccessfully()
+    {
+        var acir =
+            $@"ACIR {ACIRVersion.Current}
+
+circuit TestCircuit
+  level EL
+  supply VDD
+  ground GND
+  fill:
+    attach a to b to c via CurrentMirror::LoadBranch {{
+      SENSE -> OUT.N
+    }}
+";
+
+        var result = ACIRReader.TryParse(acir, "test.cir");
+
+        Assert.True(result.Success);
+        var attach = result.Document!.Circuits[0].Fill!.Attaches[0];
+        Assert.Equal(new[] { "b", "c" }, attach.TargetInstances);
+        Assert.NotNull(attach.Overrides);
+        Assert.Single(attach.Overrides!);
+    }
+
+    [Fact]
+    public void TryRead_AttachCombined_ParsesSuccessfully()
+    {
+        var acir =
+            $@"ACIR {ACIRVersion.Current}
+
+circuit TestCircuit
+  level EL
+  supply VDD
+  ground GND
+  fill:
+    attach a to b to c via CurrentMirror::LoadBranch as bias_net {{
+      SENSE -> OUT.N
+    }}
+";
+
+        var result = ACIRReader.TryParse(acir, "test.cir");
+
+        Assert.True(result.Success);
+        var attach = result.Document!.Circuits[0].Fill!.Attaches[0];
+        Assert.Equal("bias_net", attach.Anchor);
+        Assert.Equal(new[] { "b", "c" }, attach.TargetInstances);
+        Assert.NotNull(attach.Overrides);
+        Assert.Single(attach.Overrides!);
     }
 
     [Fact]

--- a/tests/unit/tools/acir/Cascode.ACIR.Tests/ACIRWriterHierarchyTests.cs
+++ b/tests/unit/tools/acir/Cascode.ACIR.Tests/ACIRWriterHierarchyTests.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Linq;
 using Cascode.ACIR;
 using Cascode.Parser;
 
@@ -214,7 +215,7 @@ public class ACIRWriterHierarchyTests
                             new AttachStatement
                             {
                                 SourceInstance = "cm1",
-                                TargetInstance = "load1",
+                                TargetInstances = new List<string> { "load1" },
                                 Via = "CurrentMirror::LoadBranch",
                             },
                         },
@@ -252,7 +253,7 @@ public class ACIRWriterHierarchyTests
                             new AttachStatement
                             {
                                 SourceInstance = "cm1",
-                                TargetInstance = "load1",
+                                TargetInstances = new List<string> { "load1" },
                                 Via = "CurrentMirror::LoadBranch",
                                 Anchor = "bias_net",
                             },
@@ -267,6 +268,92 @@ public class ACIRWriterHierarchyTests
         var output = writer.ToString();
 
         Assert.Contains("attach cm1 to load1 via CurrentMirror::LoadBranch as bias_net", output);
+    }
+
+    [Fact]
+    public void Write_AttachWithOverrides_ProducesValidOutput()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Attaches = new List<AttachStatement>
+                        {
+                            new AttachStatement
+                            {
+                                SourceInstance = "cm1",
+                                TargetInstances = new List<string> { "load1" },
+                                Via = "CurrentMirror::LoadBranch",
+                                Overrides = new List<ConnectorMapping>
+                                {
+                                    new ConnectorMapping
+                                    {
+                                        SourcePort = "SENSE",
+                                        TargetPort = "OUT.N",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        using var writer = new StringWriter();
+        ACIRWriter.Write(doc, writer);
+        var output = writer.ToString();
+
+        Assert.Contains("attach cm1 to load1 via CurrentMirror::LoadBranch {", output);
+        Assert.Contains("SENSE -> OUT.N", output);
+        Assert.Contains("    }", output);
+    }
+
+    [Fact]
+    public void Write_AttachChain_ProducesValidOutput()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Attaches = new List<AttachStatement>
+                        {
+                            new AttachStatement
+                            {
+                                SourceInstance = "cm1",
+                                TargetInstances = new List<string> { "load1", "load2" },
+                                Via = "CurrentMirror::LoadBranch",
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        using var writer = new StringWriter();
+        ACIRWriter.Write(doc, writer);
+        var output = writer.ToString();
+
+        Assert.Contains("attach cm1 to load1 to load2 via CurrentMirror::LoadBranch", output);
     }
 
     [Fact]
@@ -377,9 +464,103 @@ circuit TestCircuit
         Assert.True(reReadResult.Success);
         var attach = reReadResult.Document!.Circuits[0].Fill!.Attaches[0];
         Assert.Equal("cm1", attach.SourceInstance);
-        Assert.Equal("load1", attach.TargetInstance);
+        Assert.Equal("load1", attach.TargetInstances.Single());
         Assert.Equal("CurrentMirror::LoadBranch", attach.Via);
         Assert.Equal("bias_net", attach.Anchor);
+    }
+
+    [Fact]
+    public void RoundTrip_AttachWithOverrides_PreservesData()
+    {
+        var original =
+            $@"ACIR {ACIRVersion.Current}
+
+circuit TestCircuit
+  level EL
+  supply VDD
+  ground GND
+  fill:
+    attach cm1 to load1 via CurrentMirror::LoadBranch {{
+      SENSE -> OUT.N
+    }}
+";
+
+        var readResult = ACIRReader.TryParse(original, "test.cir");
+        Assert.True(readResult.Success);
+
+        using var writer = new StringWriter();
+        ACIRWriter.Write(readResult.Document!, writer);
+        var output = writer.ToString();
+
+        var reReadResult = ACIRReader.TryParse(output, "test.cir");
+        Assert.True(reReadResult.Success);
+        var attach = reReadResult.Document!.Circuits[0].Fill!.Attaches[0];
+        Assert.Equal("cm1", attach.SourceInstance);
+        Assert.Equal("load1", attach.TargetInstances.Single());
+        Assert.NotNull(attach.Overrides);
+        Assert.Single(attach.Overrides!);
+        Assert.Equal("SENSE", attach.Overrides![0].SourcePort);
+        Assert.Equal("OUT.N", attach.Overrides![0].TargetPort);
+    }
+
+    [Fact]
+    public void RoundTrip_AttachChain_PreservesData()
+    {
+        var original =
+            $@"ACIR {ACIRVersion.Current}
+
+circuit TestCircuit
+  level EL
+  supply VDD
+  ground GND
+  fill:
+    attach a to b to c via CurrentMirror::LoadBranch
+";
+
+        var readResult = ACIRReader.TryParse(original, "test.cir");
+        Assert.True(readResult.Success);
+
+        using var writer = new StringWriter();
+        ACIRWriter.Write(readResult.Document!, writer);
+        var output = writer.ToString();
+
+        var reReadResult = ACIRReader.TryParse(output, "test.cir");
+        Assert.True(reReadResult.Success);
+        var attach = reReadResult.Document!.Circuits[0].Fill!.Attaches[0];
+        Assert.Equal("a", attach.SourceInstance);
+        Assert.Equal(new[] { "b", "c" }, attach.TargetInstances);
+    }
+
+    [Fact]
+    public void RoundTrip_AttachChainWithOverrides_PreservesData()
+    {
+        var original =
+            $@"ACIR {ACIRVersion.Current}
+
+circuit TestCircuit
+  level EL
+  supply VDD
+  ground GND
+  fill:
+    attach a to b to c via CurrentMirror::LoadBranch {{
+      SENSE -> OUT.N
+    }}
+";
+
+        var readResult = ACIRReader.TryParse(original, "test.cir");
+        Assert.True(readResult.Success);
+
+        using var writer = new StringWriter();
+        ACIRWriter.Write(readResult.Document!, writer);
+        var output = writer.ToString();
+
+        var reReadResult = ACIRReader.TryParse(output, "test.cir");
+        Assert.True(reReadResult.Success);
+        var attach = reReadResult.Document!.Circuits[0].Fill!.Attaches[0];
+        Assert.Equal("a", attach.SourceInstance);
+        Assert.Equal(new[] { "b", "c" }, attach.TargetInstances);
+        Assert.NotNull(attach.Overrides);
+        Assert.Single(attach.Overrides!);
     }
 
     [Fact]

--- a/tests/unit/tools/acir/Cascode.ACIR.Tests/AcirJsonConverterBasicTests.cs
+++ b/tests/unit/tools/acir/Cascode.ACIR.Tests/AcirJsonConverterBasicTests.cs
@@ -109,7 +109,9 @@ public class AcirJsonConverterBasicTests
             ""benches"": []
         }}";
 
-        var doc = AcirJsonConverter.FromJson(json);
+        var result = AcirJsonConverter.FromJson(json);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        var doc = result.Document!;
 
         Assert.NotNull(doc);
         Assert.Single(doc.Circuits);
@@ -139,7 +141,9 @@ public class AcirJsonConverterBasicTests
             ""benches"": []
         }}";
 
-        var doc = AcirJsonConverter.FromJson(json);
+        var result = AcirJsonConverter.FromJson(json);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        var doc = result.Document!;
 
         var device = doc.Circuits[0].Fill!.Devices[0];
         Assert.Equal("nmos", device.DeviceType);
@@ -164,7 +168,9 @@ public class AcirJsonConverterBasicTests
             ""benches"": []
         }}";
 
-        var doc = AcirJsonConverter.FromJson(json);
+        var result = AcirJsonConverter.FromJson(json);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        var doc = result.Document!;
 
         Assert.Equal(3, doc.Circuits[0].Supplies.Count);
         Assert.Equal("VDD", doc.Circuits[0].Supplies[0]);

--- a/tests/unit/tools/acir/Cascode.ACIR.Tests/AcirJsonConverterConstraintsTests.cs
+++ b/tests/unit/tools/acir/Cascode.ACIR.Tests/AcirJsonConverterConstraintsTests.cs
@@ -51,7 +51,9 @@ public class AcirJsonConverterConstraintsTests
             ""benches"": []
         }}";
 
-        var doc = AcirJsonConverter.FromJson(json);
+        var result = AcirJsonConverter.FromJson(json);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        var doc = result.Document!;
 
         var constraint = doc.Circuits[0].Constraints!.Numeric[0];
         Assert.Equal("c_gbw", constraint.Id);
@@ -108,7 +110,9 @@ public class AcirJsonConverterConstraintsTests
             ""benches"": []
         }}";
 
-        var doc = AcirJsonConverter.FromJson(json);
+        var result = AcirJsonConverter.FromJson(json);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        var doc = result.Document!;
 
         var constraint = doc.Circuits[0].Constraints!.Tech[0];
         Assert.Equal("t_lmin", constraint.Id);
@@ -162,7 +166,9 @@ public class AcirJsonConverterConstraintsTests
             ""benches"": []
         }}";
 
-        var doc = AcirJsonConverter.FromJson(json);
+        var result = AcirJsonConverter.FromJson(json);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        var doc = result.Document!;
 
         var measureIntent = doc.Circuits[0].Constraints!.Measure[0];
         Assert.Equal("m_gbw", measureIntent.Id);
@@ -177,7 +183,9 @@ public class AcirJsonConverterConstraintsTests
         var original = CreateCircuitWithAllConstraintTypes();
 
         var json = AcirJsonConverter.ToJson(original);
-        var roundTripped = AcirJsonConverter.FromJson(json);
+        var result = AcirJsonConverter.FromJson(json);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        var roundTripped = result.Document!;
 
         var constraints = roundTripped.Circuits[0].Constraints!;
         Assert.Single(constraints.Numeric);

--- a/tests/unit/tools/acir/Cascode.ACIR.Tests/AcirJsonConverterEdgeCaseTests.cs
+++ b/tests/unit/tools/acir/Cascode.ACIR.Tests/AcirJsonConverterEdgeCaseTests.cs
@@ -59,7 +59,9 @@ public class AcirJsonConverterEdgeCaseTests
         };
 
         var json = AcirJsonConverter.ToJson(original);
-        var roundTripped = AcirJsonConverter.FromJson(json);
+        var result = AcirJsonConverter.FromJson(json);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        var roundTripped = result.Document!;
 
         Assert.Equal("Empty", roundTripped.Circuits[0].Name);
         Assert.Empty(roundTripped.Circuits[0].Supplies);
@@ -95,7 +97,9 @@ public class AcirJsonConverterEdgeCaseTests
         var original = CreateMinimalCircuit();
 
         var json = AcirJsonConverter.ToJson(original);
-        var roundTripped = AcirJsonConverter.FromJson(json);
+        var result = AcirJsonConverter.FromJson(json);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        var roundTripped = result.Document!;
 
         Assert.Equal("Min", roundTripped.Circuits[0].Name);
         Assert.Equal(ACIRLevel.EL, roundTripped.Circuits[0].Level);
@@ -239,7 +243,9 @@ public class AcirJsonConverterEdgeCaseTests
             ""benches"": []
         }}";
 
-        var doc = AcirJsonConverter.FromJson(json);
+        var result = AcirJsonConverter.FromJson(json);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        var doc = result.Document!;
 
         Assert.Empty(doc.Circuits[0].Supplies);
         Assert.Empty(doc.Circuits[0].Grounds);

--- a/tests/unit/tools/acir/Cascode.ACIR.Tests/AcirJsonConverterErrorTests.cs
+++ b/tests/unit/tools/acir/Cascode.ACIR.Tests/AcirJsonConverterErrorTests.cs
@@ -1,29 +1,42 @@
 using System;
 using System.Text.Json;
 using Cascode.ACIR.Json;
+using Cascode.Parser;
 
 namespace Cascode.ACIR.Tests;
 
 public class AcirJsonConverterErrorTests
 {
     [Fact]
-    public void FromJson_MalformedJson_ThrowsJsonException()
+    public void FromJson_MalformedJson_ReturnsError()
     {
         var json = "{ invalid json";
 
-        Assert.Throws<JsonException>(() => AcirJsonConverter.FromJson(json));
+        var result = AcirJsonConverter.FromJson(json);
+
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Severity == DiagnosticSeverity.Error && d.Message.Contains("ACIR0009")
+        );
     }
 
     [Fact]
-    public void FromJson_MissingRequiredFields_ThrowsJsonException()
+    public void FromJson_MissingRequiredFields_ReturnsError()
     {
         var json = $@"{{ ""acirVersion"": ""{ACIRVersion.Current}"" }}";
 
-        Assert.Throws<JsonException>(() => AcirJsonConverter.FromJson(json));
+        var result = AcirJsonConverter.FromJson(json);
+
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Severity == DiagnosticSeverity.Error && d.Message.Contains("ACIR0009")
+        );
     }
 
     [Fact]
-    public void FromJson_InvalidVersionFormat_ThrowsFormatException()
+    public void FromJson_InvalidVersionFormat_ReturnsError()
     {
         var json =
             @"{
@@ -37,12 +50,17 @@ public class AcirJsonConverterErrorTests
             ""benches"": []
         }";
 
-        var ex = Assert.Throws<FormatException>(() => AcirJsonConverter.FromJson(json));
-        Assert.Contains("Invalid ACIR version", ex.Message);
+        var result = AcirJsonConverter.FromJson(json);
+
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Severity == DiagnosticSeverity.Error && d.Message.Contains("ACIR0002")
+        );
     }
 
     [Fact]
-    public void FromJson_NonIntegerMajorVersion_ThrowsFormatException()
+    public void FromJson_NonIntegerMajorVersion_ReturnsError()
     {
         var json =
             @"{
@@ -56,13 +74,20 @@ public class AcirJsonConverterErrorTests
             ""benches"": []
         }";
 
-        var ex = Assert.Throws<FormatException>(() => AcirJsonConverter.FromJson(json));
-        Assert.Contains("Invalid ACIR version", ex.Message);
-        Assert.Contains("abc", ex.Message);
+        var result = AcirJsonConverter.FromJson(json);
+
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            d =>
+                d.Severity == DiagnosticSeverity.Error
+                && d.Message.Contains("ACIR0002")
+                && d.Message.Contains("abc")
+        );
     }
 
     [Fact]
-    public void FromJson_NonIntegerMinorVersion_ThrowsFormatException()
+    public void FromJson_NonIntegerMinorVersion_ReturnsError()
     {
         var json =
             @"{
@@ -76,13 +101,20 @@ public class AcirJsonConverterErrorTests
             ""benches"": []
         }";
 
-        var ex = Assert.Throws<FormatException>(() => AcirJsonConverter.FromJson(json));
-        Assert.Contains("Invalid ACIR version", ex.Message);
-        Assert.Contains("xyz", ex.Message);
+        var result = AcirJsonConverter.FromJson(json);
+
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            d =>
+                d.Severity == DiagnosticSeverity.Error
+                && d.Message.Contains("ACIR0002")
+                && d.Message.Contains("xyz")
+        );
     }
 
     [Fact]
-    public void FromJson_MissingDotSeparator_ThrowsFormatException()
+    public void FromJson_MissingDotSeparator_ReturnsError()
     {
         var json =
             @"{
@@ -96,13 +128,20 @@ public class AcirJsonConverterErrorTests
             ""benches"": []
         }";
 
-        var ex = Assert.Throws<FormatException>(() => AcirJsonConverter.FromJson(json));
-        Assert.Contains("Invalid ACIR version", ex.Message);
-        Assert.Contains("11", ex.Message);
+        var result = AcirJsonConverter.FromJson(json);
+
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            d =>
+                d.Severity == DiagnosticSeverity.Error
+                && d.Message.Contains("ACIR0002")
+                && d.Message.Contains("11")
+        );
     }
 
     [Fact]
-    public void FromJson_EmptyVersionString_ThrowsFormatException()
+    public void FromJson_EmptyVersionString_ReturnsError()
     {
         var json =
             @"{
@@ -116,21 +155,31 @@ public class AcirJsonConverterErrorTests
             ""benches"": []
         }";
 
-        var ex = Assert.Throws<FormatException>(() => AcirJsonConverter.FromJson(json));
-        Assert.Contains("Invalid ACIR version", ex.Message);
+        var result = AcirJsonConverter.FromJson(json);
+
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Severity == DiagnosticSeverity.Error && d.Message.Contains("ACIR0002")
+        );
     }
 
     [Fact]
-    public void FromJson_NullDocument_ThrowsArgumentException()
+    public void FromJson_NullDocument_ReturnsError()
     {
         var json = "null";
 
-        var ex = Assert.Throws<ArgumentException>(() => AcirJsonConverter.FromJson(json));
-        Assert.Contains("Failed to parse JSON document", ex.Message);
+        var result = AcirJsonConverter.FromJson(json);
+
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Severity == DiagnosticSeverity.Error && d.Message.Contains("ACIR0009")
+        );
     }
 
     [Fact]
-    public void FromJson_MissingCircuitName_ThrowsJsonException()
+    public void FromJson_MissingCircuitName_ReturnsError()
     {
         var json =
             $@"{{
@@ -144,6 +193,39 @@ public class AcirJsonConverterErrorTests
             ""benches"": []
         }}";
 
-        Assert.Throws<JsonException>(() => AcirJsonConverter.FromJson(json));
+        var result = AcirJsonConverter.FromJson(json);
+
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Severity == DiagnosticSeverity.Error && d.Message.Contains("ACIR0009")
+        );
+    }
+
+    [Fact]
+    public void FromJson_InvalidLevel_ReturnsError()
+    {
+        var json =
+            $@"{{
+            ""acirVersion"": ""{ACIRVersion.Current}"",
+            ""circuit"": {{ ""name"": ""Test"", ""level"": ""XL"" }},
+            ""supplies"": [],
+            ""grounds"": [],
+            ""ports"": [],
+            ""nets"": [],
+            ""components"": [],
+            ""benches"": []
+        }}";
+
+        var result = AcirJsonConverter.FromJson(json);
+
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            d =>
+                d.Severity == DiagnosticSeverity.Error
+                && d.Message.Contains("ACIR0008")
+                && d.Message.Contains("XL")
+        );
     }
 }

--- a/tests/unit/tools/acir/Cascode.ACIR.Tests/AcirJsonConverterHarnessTests.cs
+++ b/tests/unit/tools/acir/Cascode.ACIR.Tests/AcirJsonConverterHarnessTests.cs
@@ -118,7 +118,9 @@ public class AcirJsonConverterHarnessTests
         };
 
         var json = AcirJsonConverter.ToJson(original);
-        var roundTripped = AcirJsonConverter.FromJson(json);
+        var result = AcirJsonConverter.FromJson(json);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        var roundTripped = result.Document!;
 
         var load = roundTripped.Circuits[0].Harness!.Loads[0];
         Assert.Equal("OUT", load.Net);
@@ -177,7 +179,9 @@ public class AcirJsonConverterHarnessTests
         };
 
         var json = AcirJsonConverter.ToJson(original);
-        var roundTripped = AcirJsonConverter.FromJson(json);
+        var result = AcirJsonConverter.FromJson(json);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        var roundTripped = result.Document!;
 
         var harness = roundTripped.Circuits[0].Harness!;
         Assert.Equal(2, harness.Biases.Count);

--- a/tests/unit/tools/acir/Cascode.ACIR.Tests/AcirJsonConverterRoundTripTests.cs
+++ b/tests/unit/tools/acir/Cascode.ACIR.Tests/AcirJsonConverterRoundTripTests.cs
@@ -13,7 +13,9 @@ public class AcirJsonConverterRoundTripTests
         var original = CreateSimpleElCircuit();
 
         var json = AcirJsonConverter.ToJson(original);
-        var roundTripped = AcirJsonConverter.FromJson(json);
+        var result = AcirJsonConverter.FromJson(json);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        var roundTripped = result.Document!;
 
         Assert.Equal(original.Circuits[0].Name, roundTripped.Circuits[0].Name);
     }
@@ -24,7 +26,9 @@ public class AcirJsonConverterRoundTripTests
         var original = CreateSimpleElCircuit();
 
         var json = AcirJsonConverter.ToJson(original);
-        var roundTripped = AcirJsonConverter.FromJson(json);
+        var result = AcirJsonConverter.FromJson(json);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        var roundTripped = result.Document!;
 
         var originalDevice = original.Circuits[0].Fill!.Devices[0];
         var roundTrippedDevice = roundTripped.Circuits[0].Fill!.Devices[0];
@@ -40,7 +44,9 @@ public class AcirJsonConverterRoundTripTests
         var original = CreateCircuitWithConstraints();
 
         var json = AcirJsonConverter.ToJson(original);
-        var roundTripped = AcirJsonConverter.FromJson(json);
+        var result = AcirJsonConverter.FromJson(json);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        var roundTripped = result.Document!;
 
         var originalConstraint = original.Circuits[0].Constraints!.Numeric[0];
         var roundTrippedConstraint = roundTripped.Circuits[0].Constraints!.Numeric[0];
@@ -74,7 +80,9 @@ public class AcirJsonConverterRoundTripTests
         };
 
         var json = AcirJsonConverter.ToJson(original);
-        var roundTripped = AcirJsonConverter.FromJson(json);
+        var result = AcirJsonConverter.FromJson(json);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        var roundTripped = result.Document!;
 
         Assert.Equal(2, roundTripped.Circuits[0].Supplies.Count);
         Assert.Equal("VDD", roundTripped.Circuits[0].Supplies[0]);
@@ -90,7 +98,9 @@ public class AcirJsonConverterRoundTripTests
         var original = CreateCircuitWithBenches();
 
         var json = AcirJsonConverter.ToJson(original);
-        var roundTripped = AcirJsonConverter.FromJson(json);
+        var result = AcirJsonConverter.FromJson(json);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        var roundTripped = result.Document!;
 
         Assert.NotNull(roundTripped.Circuits[0].Benches);
         Assert.Equal(2, roundTripped.Circuits[0].Benches!.Benches.Count);
@@ -118,7 +128,9 @@ public class AcirJsonConverterRoundTripTests
         var original = CreateCircuitWithNets();
 
         var json = AcirJsonConverter.ToJson(original);
-        var roundTripped = AcirJsonConverter.FromJson(json);
+        var result = AcirJsonConverter.FromJson(json);
+        Assert.True(result.Success, string.Join("; ", result.Diagnostics.Select(d => d.Message)));
+        var roundTripped = result.Document!;
 
         Assert.NotNull(roundTripped.Circuits[0].Fill);
         Assert.Equal(2, roundTripped.Circuits[0].Fill!.Nets.Count);

--- a/tests/unit/tools/acir/Cascode.ACIR.Tests/AttachResolverTests.cs
+++ b/tests/unit/tools/acir/Cascode.ACIR.Tests/AttachResolverTests.cs
@@ -1,0 +1,1331 @@
+using System.Linq;
+using Cascode.ACIR;
+using Cascode.Parser;
+
+namespace Cascode.ACIR.Tests;
+
+public class AttachResolverTests
+{
+    [Fact]
+    public void Resolve_EmptyDocument_ReturnsSuccess()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.True(result.Success);
+        Assert.Empty(result.Diagnostics);
+    }
+
+    [Fact]
+    public void Resolve_CircuitWithNets_CreatesEquivalenceClasses()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "IN", Type = "analog" },
+                        new PortDeclaration { Name = "OUT", Type = "analog" },
+                    },
+                    Fill = new FillBlock
+                    {
+                        Nets = new List<NetDeclaration>
+                        {
+                            new NetDeclaration { Id = "internal", Domain = "analog" },
+                        },
+                    },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.True(result.Success);
+        var circuitResult = result.CircuitResults["TestCircuit"];
+
+        // Each net should be its own representative
+        Assert.Equal("VDD", circuitResult.NetToRepresentative["VDD"]);
+        Assert.Equal("GND", circuitResult.NetToRepresentative["GND"]);
+        Assert.Equal("IN", circuitResult.NetToRepresentative["IN"]);
+        Assert.Equal("OUT", circuitResult.NetToRepresentative["OUT"]);
+        Assert.Equal("internal", circuitResult.NetToRepresentative["internal"]);
+    }
+
+    [Fact]
+    public void Resolve_ConnectStatement_UnifiesNets()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Nets = new List<NetDeclaration>
+                        {
+                            new NetDeclaration { Id = "net1", Domain = "analog" },
+                            new NetDeclaration { Id = "net2", Domain = "analog" },
+                        },
+                        Connections = new List<ConnectionStatement>
+                        {
+                            new ConnectionStatement { From = "net1", To = "net2" },
+                        },
+                    },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.True(result.Success);
+        var circuitResult = result.CircuitResults["TestCircuit"];
+
+        // net1 and net2 should have the same representative
+        Assert.Equal(
+            circuitResult.NetToRepresentative["net1"],
+            circuitResult.NetToRepresentative["net2"]
+        );
+    }
+
+    [Fact]
+    public void Resolve_SupplyGroundPriority_SelectsSupplyAsRepresentative()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Nets = new List<NetDeclaration>
+                        {
+                            new NetDeclaration { Id = "power_alias", Domain = "power" },
+                        },
+                        Connections = new List<ConnectionStatement>
+                        {
+                            new ConnectionStatement { From = "power_alias", To = "VDD" },
+                        },
+                    },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.True(result.Success);
+        var circuitResult = result.CircuitResults["TestCircuit"];
+
+        // VDD should be selected as representative (supply has higher priority)
+        Assert.Equal("VDD", circuitResult.NetToRepresentative["power_alias"]);
+        Assert.Equal("VDD", circuitResult.NetToRepresentative["VDD"]);
+    }
+
+    [Fact]
+    public void Resolve_AttachWithValidConnector_CreatesBindings()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Traits = new List<TraitDefinition>
+            {
+                new TraitDefinition
+                {
+                    Name = "CurrentMirror",
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "OUT", Type = "analog" },
+                    },
+                    Connectors = new List<TraitConnector>
+                    {
+                        new TraitConnector
+                        {
+                            TargetTrait = "LoadBranch",
+                            Mappings = new List<ConnectorMapping>
+                            {
+                                new ConnectorMapping { SourcePort = "OUT", TargetPort = "IN" },
+                            },
+                        },
+                    },
+                },
+            },
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Attaches = new List<AttachStatement>
+                        {
+                            new AttachStatement
+                            {
+                                SourceInstance = "cm1",
+                                TargetInstances = new List<string> { "load1" },
+                                Via = "CurrentMirror::LoadBranch",
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.True(result.Success);
+        var circuitResult = result.CircuitResults["TestCircuit"];
+        var netName = circuitResult.TerminalToNet["cm1.OUT"];
+        Assert.Equal(netName, circuitResult.TerminalToNet["load1.IN"]);
+    }
+
+    [Fact]
+    public void Resolve_AttachWithAnchor_UsesAnchorInNetName()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Traits = new List<TraitDefinition>
+            {
+                new TraitDefinition
+                {
+                    Name = "CurrentMirror",
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "OUT", Type = "analog" },
+                    },
+                    Connectors = new List<TraitConnector>
+                    {
+                        new TraitConnector
+                        {
+                            TargetTrait = "LoadBranch",
+                            Mappings = new List<ConnectorMapping>
+                            {
+                                new ConnectorMapping { SourcePort = "OUT", TargetPort = "IN" },
+                            },
+                        },
+                    },
+                },
+            },
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Attaches = new List<AttachStatement>
+                        {
+                            new AttachStatement
+                            {
+                                SourceInstance = "cm1",
+                                TargetInstances = new List<string> { "load1" },
+                                Via = "CurrentMirror::LoadBranch",
+                                Anchor = "bias",
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.True(result.Success);
+        var circuitResult = result.CircuitResults["TestCircuit"];
+        var netName = circuitResult.TerminalToNet["cm1.OUT"];
+        Assert.Equal("bias", netName);
+        Assert.Equal(netName, circuitResult.TerminalToNet["load1.IN"]);
+    }
+
+    [Fact]
+    public void Resolve_AttachWithAnchor_MultipleMappings_UsesSuffixes()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Traits = new List<TraitDefinition>
+            {
+                new TraitDefinition
+                {
+                    Name = "CurrentMirror",
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "OUT", Type = "analog" },
+                        new PortDeclaration { Name = "REF", Type = "analog" },
+                    },
+                    Connectors = new List<TraitConnector>
+                    {
+                        new TraitConnector
+                        {
+                            TargetTrait = "LoadBranch",
+                            Mappings = new List<ConnectorMapping>
+                            {
+                                new ConnectorMapping { SourcePort = "OUT", TargetPort = "IN" },
+                                new ConnectorMapping { SourcePort = "REF", TargetPort = "REF" },
+                            },
+                        },
+                    },
+                },
+            },
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Attaches = new List<AttachStatement>
+                        {
+                            new AttachStatement
+                            {
+                                SourceInstance = "a",
+                                TargetInstances = new List<string> { "b" },
+                                Via = "CurrentMirror::LoadBranch",
+                                Anchor = "tie",
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.True(result.Success);
+        var circuitResult = result.CircuitResults["TestCircuit"];
+        Assert.Equal("tie_0", circuitResult.TerminalToNet["a.OUT"]);
+        Assert.Equal("tie_0", circuitResult.TerminalToNet["b.IN"]);
+        Assert.Equal("tie_1", circuitResult.TerminalToNet["a.REF"]);
+        Assert.Equal("tie_1", circuitResult.TerminalToNet["b.REF"]);
+    }
+
+    [Fact]
+    public void Resolve_AttachChain_AppliesPairwise()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Traits = new List<TraitDefinition>
+            {
+                new TraitDefinition
+                {
+                    Name = "CurrentMirror",
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "OUT", Type = "analog" },
+                    },
+                    Connectors = new List<TraitConnector>
+                    {
+                        new TraitConnector
+                        {
+                            TargetTrait = "LoadBranch",
+                            Mappings = new List<ConnectorMapping>
+                            {
+                                new ConnectorMapping { SourcePort = "OUT", TargetPort = "IN" },
+                            },
+                        },
+                    },
+                },
+            },
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Attaches = new List<AttachStatement>
+                        {
+                            new AttachStatement
+                            {
+                                SourceInstance = "a",
+                                TargetInstances = new List<string> { "b", "c" },
+                                Via = "CurrentMirror::LoadBranch",
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.True(result.Success);
+        var circuitResult = result.CircuitResults["TestCircuit"];
+        Assert.Equal("_auto_a_OUT__b_IN", circuitResult.TerminalToNet["a.OUT"]);
+        Assert.Equal("_auto_a_OUT__b_IN", circuitResult.TerminalToNet["b.IN"]);
+        Assert.Equal("_auto_b_OUT__c_IN", circuitResult.TerminalToNet["b.OUT"]);
+        Assert.Equal("_auto_b_OUT__c_IN", circuitResult.TerminalToNet["c.IN"]);
+    }
+
+    [Fact]
+    public void Resolve_AttachChainWithAnchor_AssignsPairwiseNames()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Traits = new List<TraitDefinition>
+            {
+                new TraitDefinition
+                {
+                    Name = "CurrentMirror",
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "OUT", Type = "analog" },
+                    },
+                    Connectors = new List<TraitConnector>
+                    {
+                        new TraitConnector
+                        {
+                            TargetTrait = "LoadBranch",
+                            Mappings = new List<ConnectorMapping>
+                            {
+                                new ConnectorMapping { SourcePort = "OUT", TargetPort = "IN" },
+                            },
+                        },
+                    },
+                },
+            },
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Attaches = new List<AttachStatement>
+                        {
+                            new AttachStatement
+                            {
+                                SourceInstance = "a",
+                                TargetInstances = new List<string> { "b", "c" },
+                                Via = "CurrentMirror::LoadBranch",
+                                Anchor = "link",
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.True(result.Success);
+        var circuitResult = result.CircuitResults["TestCircuit"];
+        Assert.Equal("link_0", circuitResult.TerminalToNet["a.OUT"]);
+        Assert.Equal("link_0", circuitResult.TerminalToNet["b.IN"]);
+        Assert.Equal("link_1", circuitResult.TerminalToNet["b.OUT"]);
+        Assert.Equal("link_1", circuitResult.TerminalToNet["c.IN"]);
+    }
+
+    [Fact]
+    public void Resolve_AttachWithOverrides_AppliesOverrideMappings()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Traits = new List<TraitDefinition>
+            {
+                new TraitDefinition
+                {
+                    Name = "CurrentMirror",
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "OUT", Type = "analog" },
+                    },
+                    Connectors = new List<TraitConnector>
+                    {
+                        new TraitConnector
+                        {
+                            TargetTrait = "LoadBranch",
+                            Mappings = new List<ConnectorMapping>
+                            {
+                                new ConnectorMapping { SourcePort = "OUT", TargetPort = "IN" },
+                            },
+                        },
+                    },
+                },
+            },
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Attaches = new List<AttachStatement>
+                        {
+                            new AttachStatement
+                            {
+                                SourceInstance = "cm1",
+                                TargetInstances = new List<string> { "load1" },
+                                Via = "CurrentMirror::LoadBranch",
+                                Overrides = new List<ConnectorMapping>
+                                {
+                                    new ConnectorMapping
+                                    {
+                                        SourcePort = "OUT",
+                                        TargetPort = "OUT.N",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.True(result.Success);
+        var circuitResult = result.CircuitResults["TestCircuit"];
+        var netName = circuitResult.TerminalToNet["cm1.OUT"];
+        Assert.Equal(netName, circuitResult.TerminalToNet["load1.OUT.N"]);
+        Assert.Equal("_auto_cm1_OUT__load1_OUT_N", netName);
+    }
+
+    [Fact]
+    public void Resolve_UndefinedTrait_ReturnsError()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Attaches = new List<AttachStatement>
+                        {
+                            new AttachStatement
+                            {
+                                SourceInstance = "cm1",
+                                TargetInstances = new List<string> { "load1" },
+                                Via = "UndefinedTrait::LoadBranch",
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Severity == DiagnosticSeverity.Error && d.Message.Contains("ACIR0021")
+        );
+    }
+
+    [Fact]
+    public void Resolve_MissingConnector_ReturnsError()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Traits = new List<TraitDefinition>
+            {
+                new TraitDefinition
+                {
+                    Name = "CurrentMirror",
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "OUT", Type = "analog" },
+                    },
+                },
+            },
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Attaches = new List<AttachStatement>
+                        {
+                            new AttachStatement
+                            {
+                                SourceInstance = "cm1",
+                                TargetInstances = new List<string> { "load1" },
+                                Via = "CurrentMirror::NonExistentTarget",
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Severity == DiagnosticSeverity.Error && d.Message.Contains("ACIR0023")
+        );
+    }
+
+    [Fact]
+    public void Resolve_IncompatibleDomains_ReturnsError()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Connections = new List<ConnectionStatement>
+                        {
+                            new ConnectionStatement { From = "VDD", To = "GND" },
+                        },
+                    },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Severity == DiagnosticSeverity.Error && d.Message.Contains("ACIR0024")
+        );
+    }
+
+    [Theory]
+    [InlineData("MalformedViaWithoutSeparator")]
+    [InlineData("")]
+    [InlineData("Single:Colon")]
+    [InlineData("A::B::C")]
+    public void Resolve_MalformedViaClause_ReturnsError(string malformedVia)
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Attaches = new List<AttachStatement>
+                        {
+                            new AttachStatement
+                            {
+                                SourceInstance = "cm1",
+                                TargetInstances = new List<string> { "load1" },
+                                Via = malformedVia,
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Severity == DiagnosticSeverity.Error && d.Message.Contains("ACIR0022")
+        );
+    }
+
+    #region Domain Compatibility Checks
+
+    [Fact]
+    public void Resolve_AttachWithMismatchedDomains_ReturnsACIR0024()
+    {
+        // Trait A: port SENSE : analog
+        // Trait B: port OUT : bias
+        // Connector: SENSE -> OUT
+        // Expect: ACIR0024 (analog != bias)
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Traits = new List<TraitDefinition>
+            {
+                new TraitDefinition
+                {
+                    Name = "SourceTrait",
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "SENSE", Type = "analog" },
+                    },
+                    Connectors = new List<TraitConnector>
+                    {
+                        new TraitConnector
+                        {
+                            TargetTrait = "TargetTrait",
+                            Mappings = new List<ConnectorMapping>
+                            {
+                                new ConnectorMapping { SourcePort = "SENSE", TargetPort = "OUT" },
+                            },
+                        },
+                    },
+                },
+                new TraitDefinition
+                {
+                    Name = "TargetTrait",
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "OUT", Type = "bias" },
+                    },
+                },
+            },
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Attaches = new List<AttachStatement>
+                        {
+                            new AttachStatement
+                            {
+                                SourceInstance = "src",
+                                TargetInstances = new List<string> { "tgt" },
+                                Via = "SourceTrait::TargetTrait",
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Severity == DiagnosticSeverity.Error && d.Message.Contains("ACIR0024")
+        );
+    }
+
+    [Fact]
+    public void Resolve_AttachWithMatchingDomains_Succeeds()
+    {
+        // Both ports are analog
+        // Expect: Success, no errors
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Traits = new List<TraitDefinition>
+            {
+                new TraitDefinition
+                {
+                    Name = "SourceTrait",
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "SENSE", Type = "analog" },
+                    },
+                    Connectors = new List<TraitConnector>
+                    {
+                        new TraitConnector
+                        {
+                            TargetTrait = "TargetTrait",
+                            Mappings = new List<ConnectorMapping>
+                            {
+                                new ConnectorMapping { SourcePort = "SENSE", TargetPort = "OUT" },
+                            },
+                        },
+                    },
+                },
+                new TraitDefinition
+                {
+                    Name = "TargetTrait",
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "OUT", Type = "analog" },
+                    },
+                },
+            },
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Attaches = new List<AttachStatement>
+                        {
+                            new AttachStatement
+                            {
+                                SourceInstance = "src",
+                                TargetInstances = new List<string> { "tgt" },
+                                Via = "SourceTrait::TargetTrait",
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.True(result.Success);
+        Assert.DoesNotContain(result.Diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void Resolve_AttachAnalogToBias_ReturnsACIR0024()
+    {
+        // Source: analog, Target: bias
+        // Expect: ACIR0024 (exact matching required)
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Traits = new List<TraitDefinition>
+            {
+                new TraitDefinition
+                {
+                    Name = "AnalogTrait",
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "SIG", Type = "analog" },
+                    },
+                    Connectors = new List<TraitConnector>
+                    {
+                        new TraitConnector
+                        {
+                            TargetTrait = "BiasTrait",
+                            Mappings = new List<ConnectorMapping>
+                            {
+                                new ConnectorMapping { SourcePort = "SIG", TargetPort = "BIAS" },
+                            },
+                        },
+                    },
+                },
+                new TraitDefinition
+                {
+                    Name = "BiasTrait",
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "BIAS", Type = "bias" },
+                    },
+                },
+            },
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Attaches = new List<AttachStatement>
+                        {
+                            new AttachStatement
+                            {
+                                SourceInstance = "analog_inst",
+                                TargetInstances = new List<string> { "bias_inst" },
+                                Via = "AnalogTrait::BiasTrait",
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Severity == DiagnosticSeverity.Error && d.Message.Contains("ACIR0024")
+        );
+    }
+
+    [Fact]
+    public void Resolve_ConnectAnalogToBias_ReturnsACIR0024()
+    {
+        // Verify exact domain matching also applies to connect statements
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Nets = new List<NetDeclaration>
+                        {
+                            new NetDeclaration { Id = "sig", Domain = "analog" },
+                            new NetDeclaration { Id = "vbias", Domain = "bias" },
+                        },
+                        Connections = new List<ConnectionStatement>
+                        {
+                            new ConnectionStatement { From = "sig", To = "vbias" },
+                        },
+                    },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.False(result.Success);
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Severity == DiagnosticSeverity.Error && d.Message.Contains("ACIR0024")
+        );
+    }
+
+    #endregion
+
+    #region Attach Override Mappings
+
+    [Fact]
+    public void Resolve_AttachWithOverrideReplacement_UsesOverriddenTarget()
+    {
+        // Connector: SENSE -> OUT.P
+        // Override: SENSE -> OUT.N
+        // Expect: Resolution uses OUT.N, not OUT.P
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Traits = new List<TraitDefinition>
+            {
+                new TraitDefinition
+                {
+                    Name = "CurrentMirror",
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "SENSE", Type = "analog" },
+                    },
+                    Connectors = new List<TraitConnector>
+                    {
+                        new TraitConnector
+                        {
+                            TargetTrait = "DiffPair",
+                            Mappings = new List<ConnectorMapping>
+                            {
+                                new ConnectorMapping { SourcePort = "SENSE", TargetPort = "OUT.P" },
+                            },
+                        },
+                    },
+                },
+                new TraitDefinition
+                {
+                    Name = "DiffPair",
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "OUT.P", Type = "analog" },
+                        new PortDeclaration { Name = "OUT.N", Type = "analog" },
+                    },
+                },
+            },
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Attaches = new List<AttachStatement>
+                        {
+                            new AttachStatement
+                            {
+                                SourceInstance = "cm",
+                                TargetInstances = new List<string> { "dp" },
+                                Via = "CurrentMirror::DiffPair",
+                                Anchor = "mirror",
+                                Overrides = new List<ConnectorMapping>
+                                {
+                                    new ConnectorMapping
+                                    {
+                                        SourcePort = "SENSE",
+                                        TargetPort = "OUT.N",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.True(result.Success);
+        var circuitResult = result.CircuitResults["TestCircuit"];
+        var attach = Assert.Single(circuitResult.AttachBindings.Keys);
+        var bindings = circuitResult.AttachBindings[attach];
+
+        // The net should reflect the overridden target (OUT.N) instead of the default (OUT.P)
+        // The binding key is the source port, and the value is the generated net name
+        Assert.True(bindings.ContainsKey("SENSE"));
+        // Net name should be based on anchor
+        Assert.Contains("mirror", bindings["SENSE"]);
+    }
+
+    [Fact]
+    public void Resolve_AttachWithInvalidOverrideSourcePort_ReturnsWarning()
+    {
+        // Override: NONEXISTENT -> OUT.N (not in connector)
+        // Expect: Warning diagnostic (unknown override source)
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Traits = new List<TraitDefinition>
+            {
+                new TraitDefinition
+                {
+                    Name = "CurrentMirror",
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "SENSE", Type = "analog" },
+                    },
+                    Connectors = new List<TraitConnector>
+                    {
+                        new TraitConnector
+                        {
+                            TargetTrait = "DiffPair",
+                            Mappings = new List<ConnectorMapping>
+                            {
+                                new ConnectorMapping { SourcePort = "SENSE", TargetPort = "OUT.P" },
+                            },
+                        },
+                    },
+                },
+                new TraitDefinition
+                {
+                    Name = "DiffPair",
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "OUT.P", Type = "analog" },
+                    },
+                },
+            },
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Attaches = new List<AttachStatement>
+                        {
+                            new AttachStatement
+                            {
+                                SourceInstance = "cm",
+                                TargetInstances = new List<string> { "dp" },
+                                Via = "CurrentMirror::DiffPair",
+                                Overrides = new List<ConnectorMapping>
+                                {
+                                    new ConnectorMapping
+                                    {
+                                        SourcePort = "NONEXISTENT",
+                                        TargetPort = "OUT.N",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        // Should still succeed (warning, not error) but have a warning diagnostic
+        Assert.Contains(
+            result.Diagnostics,
+            d => d.Severity == DiagnosticSeverity.Warning && d.Message.Contains("NONEXISTENT")
+        );
+    }
+
+    #endregion
+
+    #region Duplicate Name Handling
+
+    [Fact]
+    public void Resolve_DuplicateTraitNames_EmitsWarningAndKeepsFirst()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Traits = new List<TraitDefinition>
+            {
+                new TraitDefinition
+                {
+                    Name = "DuplicateTrait",
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "FirstPort", Type = "analog" },
+                    },
+                },
+                new TraitDefinition
+                {
+                    Name = "DuplicateTrait",
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "SecondPort", Type = "analog" },
+                    },
+                },
+            },
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.True(result.Success);
+        var warning = Assert.Single(
+            result.Diagnostics,
+            d => d.Code == "ACIR0026" && d.Message.Contains("trait")
+        );
+        Assert.Contains("DuplicateTrait", warning.Message);
+        Assert.Contains("keeping first definition", warning.Message);
+        Assert.Equal(DiagnosticSeverity.Warning, warning.Severity);
+    }
+
+    [Fact]
+    public void Resolve_DuplicateCircuitNames_EmitsWarningAndKeepsFirst()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "DuplicateCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Nets = new List<NetDeclaration>
+                        {
+                            new NetDeclaration { Id = "net1", Domain = "analog" },
+                        },
+                    },
+                },
+                new Circuit
+                {
+                    Name = "DuplicateCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDDA" },
+                    Grounds = new List<string> { "GNDA" },
+                    Fill = new FillBlock
+                    {
+                        Nets = new List<NetDeclaration>
+                        {
+                            new NetDeclaration { Id = "net2", Domain = "analog" },
+                        },
+                    },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.True(result.Success);
+        var warning = Assert.Single(
+            result.Diagnostics,
+            d => d.Code == "ACIR0026" && d.Message.Contains("circuit")
+        );
+        Assert.Contains("DuplicateCircuit", warning.Message);
+        Assert.Contains("keeping first definition", warning.Message);
+        Assert.Equal(DiagnosticSeverity.Warning, warning.Severity);
+    }
+
+    [Fact]
+    public void Resolve_DuplicateBundleTypeNames_EmitsWarningAndKeepsFirst()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            BundleTypes = new List<BundleType>
+            {
+                new BundleType
+                {
+                    Name = "DuplicateBundle",
+                    Fields = new Dictionary<string, string>
+                    {
+                        { "P", "analog" },
+                        { "N", "analog" },
+                    },
+                },
+                new BundleType
+                {
+                    Name = "DuplicateBundle",
+                    Fields = new Dictionary<string, string>
+                    {
+                        { "A", "analog" },
+                        { "B", "analog" },
+                        { "C", "analog" },
+                    },
+                },
+            },
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TestCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var result = resolver.Resolve();
+
+        Assert.True(result.Success);
+        var warning = Assert.Single(
+            result.Diagnostics,
+            d => d.Code == "ACIR0026" && d.Message.Contains("bundle type")
+        );
+        Assert.Contains("DuplicateBundle", warning.Message);
+        Assert.Contains("keeping first definition", warning.Message);
+        Assert.Equal(DiagnosticSeverity.Warning, warning.Severity);
+    }
+
+    #endregion
+}

--- a/tests/unit/tools/acir/Cascode.ACIR.Tests/HierarchyValidatorTests.cs
+++ b/tests/unit/tools/acir/Cascode.ACIR.Tests/HierarchyValidatorTests.cs
@@ -222,7 +222,7 @@ public class HierarchyValidatorTests
                             new AttachStatement
                             {
                                 SourceInstance = "nonexistent1",
-                                TargetInstance = "nonexistent2",
+                                TargetInstances = new List<string> { "nonexistent2" },
                                 Via = "SomeTrait::OtherTrait",
                             },
                         },
@@ -353,7 +353,7 @@ public class HierarchyValidatorTests
                             new AttachStatement
                             {
                                 SourceInstance = "cm1",
-                                TargetInstance = "load1",
+                                TargetInstances = new List<string> { "load1" },
                                 Via = "CurrentMirror::LoadBranch",
                             },
                         },
@@ -678,7 +678,7 @@ public class HierarchyValidatorTests
                             new AttachStatement
                             {
                                 SourceInstance = "drv1",
-                                TargetInstance = "rcv1",
+                                TargetInstances = new List<string> { "rcv1" },
                                 Via = "Driver::Receiver",
                             },
                         },

--- a/tests/unit/tools/acir/Cascode.ACIR.Tests/ParamValueParserTests.cs
+++ b/tests/unit/tools/acir/Cascode.ACIR.Tests/ParamValueParserTests.cs
@@ -1,0 +1,147 @@
+using Cascode.ACIR;
+
+namespace Cascode.ACIR.Tests;
+
+public class ParamValueParserTests
+{
+    [Fact]
+    public void Parse_SymbolicValue_ReturnsSymbolic()
+    {
+        var result = ParamValueParser.Parse("$ratio");
+
+        Assert.NotNull(result.Symbolic);
+        Assert.Equal("$ratio", result.Symbolic);
+        Assert.Null(result.Numeric);
+        Assert.Null(result.Literal);
+    }
+
+    [Fact]
+    public void Parse_SymbolicWithUnderscore_ReturnsSymbolic()
+    {
+        var result = ParamValueParser.Parse("$my_param");
+
+        Assert.NotNull(result.Symbolic);
+        Assert.Equal("$my_param", result.Symbolic);
+        Assert.Null(result.Numeric);
+        Assert.Null(result.Literal);
+    }
+
+    [Theory]
+    [InlineData("10k")]
+    [InlineData("-1.5M")]
+    [InlineData("180n")]
+    [InlineData("2u")]
+    [InlineData("1.8")]
+    [InlineData("100")]
+    [InlineData("-5")]
+    [InlineData("3.14")]
+    [InlineData("1pF")]
+    [InlineData("10MOhm")]
+    [InlineData("500fF")]
+    public void Parse_NumericValues_ReturnsNumeric(string value)
+    {
+        var result = ParamValueParser.Parse(value);
+
+        Assert.NotNull(result.Numeric);
+        Assert.Equal(value, result.Numeric);
+        Assert.Null(result.Symbolic);
+        Assert.Null(result.Literal);
+    }
+
+    [Theory]
+    [InlineData("res1stor")]
+    [InlineData("nmos2")]
+    [InlineData("high_z")]
+    [InlineData("sky130_fd_pr__nfet_01v8")]
+    [InlineData("auto")]
+    [InlineData("MyDevice")]
+    public void Parse_LiteralValues_ReturnsLiteral(string value)
+    {
+        var result = ParamValueParser.Parse(value);
+
+        Assert.NotNull(result.Literal);
+        Assert.Equal(value, result.Literal);
+        Assert.Null(result.Symbolic);
+        Assert.Null(result.Numeric);
+    }
+
+    [Fact]
+    public void Parse_EmptyString_ReturnsLiteral()
+    {
+        var result = ParamValueParser.Parse("");
+
+        Assert.NotNull(result.Literal);
+        Assert.Equal("", result.Literal);
+        Assert.Null(result.Symbolic);
+        Assert.Null(result.Numeric);
+    }
+
+    [Theory]
+    [InlineData("10k", true)]
+    [InlineData("-1.5M", true)]
+    [InlineData("res1stor", false)]
+    [InlineData("nmos2", false)]
+    [InlineData("device1", false)]
+    public void Parse_CorrectlyDistinguishesNumericFromLiteral(string value, bool shouldBeNumeric)
+    {
+        var result = ParamValueParser.Parse(value);
+
+        if (shouldBeNumeric)
+        {
+            Assert.NotNull(result.Numeric);
+            Assert.Null(result.Literal);
+        }
+        else
+        {
+            Assert.NotNull(result.Literal);
+            Assert.Null(result.Numeric);
+        }
+    }
+
+    [Theory]
+    [InlineData("1.5V")]
+    [InlineData("100mV")]
+    [InlineData("1.8GHz")]
+    [InlineData("50Ohm")]
+    public void Parse_NumericWithUnits_ReturnsNumeric(string value)
+    {
+        var result = ParamValueParser.Parse(value);
+
+        Assert.NotNull(result.Numeric);
+        Assert.Equal(value, result.Numeric);
+        Assert.Null(result.Symbolic);
+        Assert.Null(result.Literal);
+    }
+
+    [Fact]
+    public void Parse_DecimalWithoutInteger_ReturnsLiteral()
+    {
+        // ".5" should be treated as literal since it doesn't match the pattern
+        var result = ParamValueParser.Parse(".5");
+
+        Assert.NotNull(result.Literal);
+        Assert.Null(result.Numeric);
+        Assert.Null(result.Symbolic);
+    }
+
+    [Fact]
+    public void Parse_LeadingZeroDecimal_ReturnsNumeric()
+    {
+        var result = ParamValueParser.Parse("0.5");
+
+        Assert.NotNull(result.Numeric);
+        Assert.Null(result.Literal);
+        Assert.Null(result.Symbolic);
+    }
+
+    [Fact]
+    public void Parse_NumberWithUnusualUnit_ReturnsNumeric()
+    {
+        // "10x" - even with non-standard unit, if it starts with digit it's numeric
+        var result = ParamValueParser.Parse("10x");
+
+        Assert.NotNull(result.Numeric);
+        Assert.Null(result.Literal);
+        Assert.Null(result.Symbolic);
+    }
+}

--- a/tests/unit/tools/acir/Cascode.ACIR.Tests/ParameterEvaluatorTests.cs
+++ b/tests/unit/tools/acir/Cascode.ACIR.Tests/ParameterEvaluatorTests.cs
@@ -1,0 +1,219 @@
+using Cascode.ACIR;
+
+namespace Cascode.ACIR.Tests;
+
+public class ParameterEvaluatorTests
+{
+    [Fact]
+    public void Evaluate_NumericLiteral_ReturnsUnchanged()
+    {
+        var bindings = new Dictionary<string, string>();
+
+        var result = ParameterEvaluator.Evaluate("100", bindings);
+
+        Assert.Equal("100", result);
+    }
+
+    [Fact]
+    public void Evaluate_NumericWithSIPrefix_ReturnsUnchanged()
+    {
+        var bindings = new Dictionary<string, string>();
+
+        var result = ParameterEvaluator.Evaluate("2u", bindings);
+
+        Assert.Equal("2u", result);
+    }
+
+    [Fact]
+    public void Evaluate_SymbolicReference_Substitutes()
+    {
+        var bindings = new Dictionary<string, string> { ["width"] = "1u" };
+
+        var result = ParameterEvaluator.Evaluate("$width", bindings);
+
+        Assert.Equal("1u", result);
+    }
+
+    [Fact]
+    public void Evaluate_Multiplication_Computes()
+    {
+        var bindings = new Dictionary<string, string> { ["W_input"] = "1u" };
+
+        var result = ParameterEvaluator.Evaluate("$W_input*2", bindings);
+
+        Assert.Equal("2u", result);
+    }
+
+    [Fact]
+    public void Evaluate_Division_Computes()
+    {
+        var bindings = new Dictionary<string, string> { ["W_input"] = "4u" };
+
+        var result = ParameterEvaluator.Evaluate("$W_input/2", bindings);
+
+        Assert.Equal("2u", result);
+    }
+
+    [Fact]
+    public void Evaluate_Addition_Computes()
+    {
+        var bindings = new Dictionary<string, string>();
+
+        var result = ParameterEvaluator.Evaluate("1u+1u", bindings);
+
+        Assert.Equal("2u", result);
+    }
+
+    [Fact]
+    public void Evaluate_Subtraction_Computes()
+    {
+        var bindings = new Dictionary<string, string>();
+
+        var result = ParameterEvaluator.Evaluate("3u-1u", bindings);
+
+        Assert.Equal("2u", result);
+    }
+
+    [Fact]
+    public void Evaluate_ChainedReference_ResolvesRecursively()
+    {
+        var bindings = new Dictionary<string, string>
+        {
+            ["actual_width"] = "1u",
+            ["W"] = "$actual_width",
+        };
+
+        var result = ParameterEvaluator.Evaluate("$W", bindings);
+
+        Assert.Equal("1u", result);
+    }
+
+    [Fact]
+    public void Evaluate_MultipleOperations_EvaluatesLeftToRight()
+    {
+        var bindings = new Dictionary<string, string> { ["ratio"] = "2" };
+
+        // $ratio*2+1 = 2*2+1 = 5 (left-to-right, no precedence)
+        var result = ParameterEvaluator.Evaluate("$ratio*2+1", bindings);
+
+        Assert.Equal("5", result);
+    }
+
+    [Fact]
+    public void Evaluate_UndefinedParameter_ThrowsArgumentException()
+    {
+        var bindings = new Dictionary<string, string>();
+
+        var ex = Assert.Throws<ArgumentException>(() =>
+            ParameterEvaluator.Evaluate("$undefined", bindings)
+        );
+
+        Assert.Contains("Undefined parameter reference", ex.Message);
+    }
+
+    [Fact]
+    public void Evaluate_CircularReference_ThrowsArgumentException()
+    {
+        var bindings = new Dictionary<string, string> { ["A"] = "$B", ["B"] = "$A" };
+
+        var ex = Assert.Throws<ArgumentException>(() =>
+            ParameterEvaluator.Evaluate("$A", bindings)
+        );
+
+        Assert.Contains("Circular", ex.Message);
+    }
+
+    [Theory]
+    [InlineData("1f", 1e-15)]
+    [InlineData("1p", 1e-12)]
+    [InlineData("1n", 1e-9)]
+    [InlineData("1u", 1e-6)]
+    [InlineData("1m", 1e-3)]
+    [InlineData("1k", 1e3)]
+    [InlineData("1M", 1e6)]
+    [InlineData("1G", 1e9)]
+    [InlineData("1T", 1e12)]
+    public void ParseNumeric_AllPrefixes_ParsesCorrectly(string input, double expected)
+    {
+        var result = ParameterEvaluator.ParseNumeric(input);
+
+        Assert.Equal(expected, result, precision: 10);
+    }
+
+    [Fact]
+    public void ParseNumeric_DecimalWithPrefix_ParsesCorrectly()
+    {
+        var result = ParameterEvaluator.ParseNumeric("2.5u");
+
+        Assert.Equal(2.5e-6, result, precision: 15);
+    }
+
+    [Fact]
+    public void ParseNumeric_ScientificNotation_ParsesCorrectly()
+    {
+        var result = ParameterEvaluator.ParseNumeric("1e-6");
+
+        Assert.Equal(1e-6, result, precision: 15);
+    }
+
+    [Fact]
+    public void ParseNumeric_NoPrefix_ParsesCorrectly()
+    {
+        var result = ParameterEvaluator.ParseNumeric("42");
+
+        Assert.Equal(42, result);
+    }
+
+    [Theory]
+    [InlineData(1e-15, "1f")]
+    [InlineData(1e-12, "1p")]
+    [InlineData(1e-9, "1n")]
+    [InlineData(1e-6, "1u")]
+    [InlineData(1e-3, "1m")]
+    [InlineData(1e3, "1k")]
+    [InlineData(1e6, "1M")]
+    [InlineData(1e9, "1G")]
+    [InlineData(1e12, "1T")]
+    public void FormatNumeric_SelectsAppropriatePrefix(double input, string expected)
+    {
+        var result = ParameterEvaluator.FormatNumeric(input);
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void FormatNumeric_Zero_ReturnsZero()
+    {
+        var result = ParameterEvaluator.FormatNumeric(0);
+
+        Assert.Equal("0", result);
+    }
+
+    [Fact]
+    public void FormatNumeric_NonPrefixableValue_ReturnsPlainNumber()
+    {
+        var result = ParameterEvaluator.FormatNumeric(42);
+
+        Assert.Equal("42", result);
+    }
+
+    [Fact]
+    public void Evaluate_ComplexExpression_ComputesCorrectly()
+    {
+        var bindings = new Dictionary<string, string> { ["W_input"] = "1u", ["tail_ratio"] = "4" };
+
+        var result = ParameterEvaluator.Evaluate("$W_input*$tail_ratio", bindings);
+
+        Assert.Equal("4u", result);
+    }
+
+    [Fact]
+    public void Evaluate_EmptyExpression_ThrowsArgumentException()
+    {
+        var bindings = new Dictionary<string, string>();
+
+        var ex = Assert.Throws<ArgumentException>(() => ParameterEvaluator.Evaluate("", bindings));
+
+        Assert.Contains("Empty or invalid", ex.Message);
+    }
+}

--- a/tests/unit/tools/acir/Cascode.ACIR.Tests/SpiceEmitterHierarchyTests.cs
+++ b/tests/unit/tools/acir/Cascode.ACIR.Tests/SpiceEmitterHierarchyTests.cs
@@ -1,0 +1,1074 @@
+using System.IO;
+using Cascode.ACIR;
+using Cascode.ACIR.Validation;
+using Cascode.TestSupport;
+
+namespace Cascode.ACIR.Tests;
+
+public class SpiceEmitterHierarchyTests
+{
+    [Fact]
+    public void EmitDesign_WithInstance_EmitsXElement()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "ChildCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "IN", Type = "analog" },
+                        new PortDeclaration { Name = "OUT", Type = "analog" },
+                    },
+                },
+                new Circuit
+                {
+                    Name = "TopLevel",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "SIG_IN", Type = "analog" },
+                        new PortDeclaration { Name = "SIG_OUT", Type = "analog" },
+                    },
+                    Fill = new FillBlock
+                    {
+                        Instances = new List<InstanceDeclaration>
+                        {
+                            new InstanceDeclaration
+                            {
+                                Id = "child1",
+                                Type = "ChildCircuit",
+                                Bindings = new Dictionary<string, string>
+                                {
+                                    ["IN"] = "SIG_IN",
+                                    ["OUT"] = "SIG_OUT",
+                                    ["VDD"] = "VDD",
+                                    ["GND"] = "GND",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var topLevel = doc.Circuits.First(c => c.Name == "TopLevel");
+
+        using var writer = new StringWriter();
+        SpiceEmitter.EmitDesign(topLevel, writer, document: doc);
+        var output = writer.ToString();
+
+        Assert.Contains("Xchild1", output);
+        Assert.Contains("SIG_IN SIG_OUT VDD GND ChildCircuit", output);
+    }
+
+    [Fact]
+    public void EmitDesign_InstancePortOrder_MatchesSubcktDeclaration()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "ThreePortChild",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "AVDD", "DVDD" },
+                    Grounds = new List<string> { "VSS" },
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "A", Type = "analog" },
+                        new PortDeclaration { Name = "B", Type = "analog" },
+                        new PortDeclaration { Name = "Y", Type = "analog" },
+                    },
+                },
+                new Circuit
+                {
+                    Name = "Parent",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Instances = new List<InstanceDeclaration>
+                        {
+                            new InstanceDeclaration
+                            {
+                                Id = "u1",
+                                Type = "ThreePortChild",
+                                Bindings = new Dictionary<string, string>
+                                {
+                                    ["A"] = "net_a",
+                                    ["B"] = "net_b",
+                                    ["Y"] = "net_y",
+                                    ["AVDD"] = "VDD",
+                                    ["DVDD"] = "VDD",
+                                    ["VSS"] = "GND",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var parent = doc.Circuits.First(c => c.Name == "Parent");
+
+        using var writer = new StringWriter();
+        SpiceEmitter.EmitDesign(parent, writer, document: doc);
+        var output = writer.ToString();
+
+        // Port order should be: A B Y AVDD DVDD VSS (ports, then supplies, then grounds)
+        Assert.Contains("Xu1 net_a net_b net_y VDD VDD GND ThreePortChild", output);
+    }
+
+    [Fact]
+    public void EmitDesign_WithAttachResolution_UsesResolvedNets()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "ChildCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "OUT", Type = "analog" },
+                    },
+                },
+                new Circuit
+                {
+                    Name = "TopLevel",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Instances = new List<InstanceDeclaration>
+                        {
+                            new InstanceDeclaration
+                            {
+                                Id = "child1",
+                                Type = "ChildCircuit",
+                                Bindings = new Dictionary<string, string>
+                                {
+                                    ["OUT"] = "internal_net",
+                                    ["VDD"] = "VDD",
+                                    ["GND"] = "GND",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var topLevel = doc.Circuits.First(c => c.Name == "TopLevel");
+
+        // Create a resolution that maps internal_net to a different representative
+        var resolution = new CircuitResolutionResult();
+        resolution._netToRepresentative["internal_net"] = "resolved_output";
+
+        using var writer = new StringWriter();
+        SpiceEmitter.EmitDesign(topLevel, writer, document: doc, resolution: resolution);
+        var output = writer.ToString();
+
+        // Should use resolved net name
+        Assert.Contains("resolved_output", output);
+        Assert.DoesNotContain("internal_net", output);
+    }
+
+    [Fact]
+    public void EmitDesign_AttachResolution_UsesTerminalToNet()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Traits = new List<TraitDefinition>
+            {
+                new TraitDefinition
+                {
+                    Name = "TraitA",
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "OUT", Type = "analog" },
+                    },
+                    Connectors = new List<TraitConnector>
+                    {
+                        new TraitConnector
+                        {
+                            TargetTrait = "TraitB",
+                            Mappings = new List<ConnectorMapping>
+                            {
+                                new ConnectorMapping { SourcePort = "OUT", TargetPort = "IN" },
+                            },
+                        },
+                    },
+                },
+            },
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "Source",
+                    Level = ACIRLevel.EL,
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "OUT", Type = "analog" },
+                    },
+                },
+                new Circuit
+                {
+                    Name = "Target",
+                    Level = ACIRLevel.EL,
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "IN", Type = "analog" },
+                    },
+                },
+                new Circuit
+                {
+                    Name = "Top",
+                    Level = ACIRLevel.EL,
+                    Fill = new FillBlock
+                    {
+                        Instances = new List<InstanceDeclaration>
+                        {
+                            new InstanceDeclaration { Id = "a", Type = "Source" },
+                            new InstanceDeclaration { Id = "b", Type = "Target" },
+                        },
+                        Attaches = new List<AttachStatement>
+                        {
+                            new AttachStatement
+                            {
+                                SourceInstance = "a",
+                                TargetInstances = new List<string> { "b" },
+                                Via = "TraitA::TraitB",
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var resolver = new AttachResolver(doc);
+        var resolution = resolver.Resolve().CircuitResults["Top"];
+        var topLevel = doc.Circuits.First(c => c.Name == "Top");
+
+        using var writer = new StringWriter();
+        SpiceEmitter.EmitDesign(topLevel, writer, document: doc, resolution: resolution);
+        var output = writer.ToString();
+
+        Assert.Contains("Xa _auto_a_OUT__b_IN Source", output);
+        Assert.Contains("Xb _auto_a_OUT__b_IN Target", output);
+    }
+
+    [Fact]
+    public void EmitDesign_MultipleInstances_EmitsAllXElements()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "Inverter",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "IN", Type = "analog" },
+                        new PortDeclaration { Name = "OUT", Type = "analog" },
+                    },
+                },
+                new Circuit
+                {
+                    Name = "BufferChain",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "A", Type = "analog" },
+                        new PortDeclaration { Name = "Y", Type = "analog" },
+                    },
+                    Fill = new FillBlock
+                    {
+                        Nets = new List<NetDeclaration>
+                        {
+                            new NetDeclaration { Id = "n1", Domain = "analog" },
+                        },
+                        Instances = new List<InstanceDeclaration>
+                        {
+                            new InstanceDeclaration
+                            {
+                                Id = "inv1",
+                                Type = "Inverter",
+                                Bindings = new Dictionary<string, string>
+                                {
+                                    ["IN"] = "A",
+                                    ["OUT"] = "n1",
+                                    ["VDD"] = "VDD",
+                                    ["GND"] = "GND",
+                                },
+                            },
+                            new InstanceDeclaration
+                            {
+                                Id = "inv2",
+                                Type = "Inverter",
+                                Bindings = new Dictionary<string, string>
+                                {
+                                    ["IN"] = "n1",
+                                    ["OUT"] = "Y",
+                                    ["VDD"] = "VDD",
+                                    ["GND"] = "GND",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var bufferChain = doc.Circuits.First(c => c.Name == "BufferChain");
+
+        using var writer = new StringWriter();
+        SpiceEmitter.EmitDesign(bufferChain, writer, document: doc);
+        var output = writer.ToString();
+
+        Assert.Contains("Xinv1 A n1 VDD GND Inverter", output);
+        Assert.Contains("Xinv2 n1 Y VDD GND Inverter", output);
+    }
+
+    [Fact]
+    public void EmitDesign_NoDocument_SkipsInstances()
+    {
+        var circuit = new Circuit
+        {
+            Name = "TopLevel",
+            Level = ACIRLevel.EL,
+            Supplies = new List<string> { "VDD" },
+            Grounds = new List<string> { "GND" },
+            Fill = new FillBlock
+            {
+                Instances = new List<InstanceDeclaration>
+                {
+                    new InstanceDeclaration
+                    {
+                        Id = "child1",
+                        Type = "ChildCircuit",
+                        Bindings = new Dictionary<string, string>
+                        {
+                            ["VDD"] = "VDD",
+                            ["GND"] = "GND",
+                        },
+                    },
+                },
+            },
+        };
+
+        using var writer = new StringWriter();
+        SpiceEmitter.EmitDesign(circuit, writer);
+        var output = writer.ToString();
+
+        // Should not emit X-element without document to resolve type
+        Assert.DoesNotContain("Xchild1", output);
+    }
+
+    [Fact]
+    public void EmitDesign_InlineCircuit_ExpandsDevices()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "InverterCell",
+                    Level = ACIRLevel.EL,
+                    Inline = true, // Marked for inline expansion
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "IN", Type = "analog" },
+                        new PortDeclaration { Name = "OUT", Type = "analog" },
+                    },
+                    Fill = new FillBlock
+                    {
+                        Devices = new List<DeviceDeclaration>
+                        {
+                            new DeviceDeclaration
+                            {
+                                DeviceType = "pmos",
+                                Id = "MP",
+                                Bindings = new Dictionary<string, string>
+                                {
+                                    ["D"] = "OUT",
+                                    ["G"] = "IN",
+                                    ["S"] = "VDD",
+                                    ["B"] = "VDD",
+                                },
+                                Params = new Dictionary<string, string>
+                                {
+                                    ["W"] = "2u",
+                                    ["L"] = "100n",
+                                },
+                            },
+                            new DeviceDeclaration
+                            {
+                                DeviceType = "nmos",
+                                Id = "MN",
+                                Bindings = new Dictionary<string, string>
+                                {
+                                    ["D"] = "OUT",
+                                    ["G"] = "IN",
+                                    ["S"] = "GND",
+                                    ["B"] = "GND",
+                                },
+                                Params = new Dictionary<string, string>
+                                {
+                                    ["W"] = "1u",
+                                    ["L"] = "100n",
+                                },
+                            },
+                        },
+                    },
+                },
+                new Circuit
+                {
+                    Name = "BufferTop",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "A", Type = "analog" },
+                        new PortDeclaration { Name = "Y", Type = "analog" },
+                    },
+                    Fill = new FillBlock
+                    {
+                        Instances = new List<InstanceDeclaration>
+                        {
+                            new InstanceDeclaration
+                            {
+                                Id = "inv1",
+                                Type = "InverterCell",
+                                Bindings = new Dictionary<string, string>
+                                {
+                                    ["IN"] = "A",
+                                    ["OUT"] = "Y",
+                                    ["VDD"] = "VDD",
+                                    ["GND"] = "GND",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var bufferTop = doc.Circuits.First(c => c.Name == "BufferTop");
+
+        using var writer = new StringWriter();
+        SpiceEmitter.EmitDesign(bufferTop, writer, document: doc);
+        var output = writer.ToString();
+
+        // Should NOT emit X-element for inline circuit
+        Assert.DoesNotContain("Xinv1", output);
+
+        // Should emit expanded devices with hierarchical naming
+        Assert.Contains("Minv1__MP", output);
+        Assert.Contains("Minv1__MN", output);
+
+        // Check inline expansion comment
+        Assert.Contains("Inline expansion of inv1 : InverterCell", output);
+    }
+
+    [Fact]
+    public void EmitDesign_InlineCircuit_UniquifiesNetNames()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "BufferCell",
+                    Level = ACIRLevel.EL,
+                    Inline = true,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "IN", Type = "analog" },
+                        new PortDeclaration { Name = "OUT", Type = "analog" },
+                    },
+                    Fill = new FillBlock
+                    {
+                        Nets = new List<NetDeclaration>
+                        {
+                            new NetDeclaration { Id = "mid", Domain = "analog" },
+                        },
+                        Devices = new List<DeviceDeclaration>
+                        {
+                            new DeviceDeclaration
+                            {
+                                DeviceType = "nmos",
+                                Id = "M1",
+                                Bindings = new Dictionary<string, string>
+                                {
+                                    ["D"] = "mid",
+                                    ["G"] = "IN",
+                                    ["S"] = "GND",
+                                    ["B"] = "GND",
+                                },
+                                Params = new Dictionary<string, string>
+                                {
+                                    ["W"] = "1u",
+                                    ["L"] = "100n",
+                                },
+                            },
+                            new DeviceDeclaration
+                            {
+                                DeviceType = "nmos",
+                                Id = "M2",
+                                Bindings = new Dictionary<string, string>
+                                {
+                                    ["D"] = "OUT",
+                                    ["G"] = "mid",
+                                    ["S"] = "GND",
+                                    ["B"] = "GND",
+                                },
+                                Params = new Dictionary<string, string>
+                                {
+                                    ["W"] = "1u",
+                                    ["L"] = "100n",
+                                },
+                            },
+                        },
+                    },
+                },
+                new Circuit
+                {
+                    Name = "TopLevel",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "A", Type = "analog" },
+                        new PortDeclaration { Name = "Y", Type = "analog" },
+                    },
+                    Fill = new FillBlock
+                    {
+                        Instances = new List<InstanceDeclaration>
+                        {
+                            new InstanceDeclaration
+                            {
+                                Id = "buf1",
+                                Type = "BufferCell",
+                                Bindings = new Dictionary<string, string>
+                                {
+                                    ["IN"] = "A",
+                                    ["OUT"] = "Y",
+                                    ["VDD"] = "VDD",
+                                    ["GND"] = "GND",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var topLevel = doc.Circuits.First(c => c.Name == "TopLevel");
+
+        using var writer = new StringWriter();
+        SpiceEmitter.EmitDesign(topLevel, writer, document: doc);
+        var output = writer.ToString();
+
+        // Internal net "mid" should be uniquified with instance prefix
+        Assert.Contains("buf1__mid", output);
+    }
+
+    [Fact]
+    public void EmitDesign_InlineCircuit_SubstitutesPortBindings()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "Resistor",
+                    Level = ACIRLevel.EL,
+                    Inline = true,
+                    Supplies = new List<string>(),
+                    Grounds = new List<string>(),
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "P", Type = "analog" },
+                        new PortDeclaration { Name = "N", Type = "analog" },
+                    },
+                    Fill = new FillBlock
+                    {
+                        Devices = new List<DeviceDeclaration>
+                        {
+                            new DeviceDeclaration
+                            {
+                                DeviceType = "resistor",
+                                Id = "R1",
+                                Bindings = new Dictionary<string, string>
+                                {
+                                    ["P"] = "P",
+                                    ["N"] = "N",
+                                },
+                                Params = new Dictionary<string, string> { ["R"] = "1k" },
+                            },
+                        },
+                    },
+                },
+                new Circuit
+                {
+                    Name = "TopLevel",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Ports = new List<PortDeclaration>
+                    {
+                        new PortDeclaration { Name = "OUT", Type = "analog" },
+                    },
+                    Fill = new FillBlock
+                    {
+                        Instances = new List<InstanceDeclaration>
+                        {
+                            new InstanceDeclaration
+                            {
+                                Id = "rload",
+                                Type = "Resistor",
+                                Bindings = new Dictionary<string, string>
+                                {
+                                    ["P"] = "OUT",
+                                    ["N"] = "GND",
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        var topLevel = doc.Circuits.First(c => c.Name == "TopLevel");
+
+        using var writer = new StringWriter();
+        SpiceEmitter.EmitDesign(topLevel, writer, document: doc);
+        var output = writer.ToString();
+
+        // Port bindings should be substituted: P->OUT, N->GND
+        Assert.Contains("Rrload__R1 OUT GND 1k", output);
+    }
+
+    [Fact]
+    public void ValidateAndEmit_InvalidHierarchy_ReturnsErrors()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "TopLevel",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Instances = new List<InstanceDeclaration>
+                        {
+                            new InstanceDeclaration
+                            {
+                                Id = "child1",
+                                Type = "UndefinedCircuit", // Invalid reference
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        using var cascodeHome = CascodeHome.CreateInTemp("SpiceEmitterTest");
+        var tempDir = cascodeHome.Path;
+
+        var result = SpiceEmitter.ValidateAndEmit(doc, tempDir);
+
+        Assert.False(result.Success);
+        Assert.Contains(result.Validation.GetErrors(), e => e.Code == "HIER-001");
+    }
+
+    [Fact]
+    public void Emit_DependencyOrder_LeafFirst()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Circuits = new List<Circuit>
+            {
+                // Defined in reverse order (top-level first)
+                new Circuit
+                {
+                    Name = "TopLevel",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                    Fill = new FillBlock
+                    {
+                        Instances = new List<InstanceDeclaration>
+                        {
+                            new InstanceDeclaration
+                            {
+                                Id = "child1",
+                                Type = "ChildCircuit",
+                                Bindings = new Dictionary<string, string>
+                                {
+                                    ["VDD"] = "VDD",
+                                    ["GND"] = "GND",
+                                },
+                            },
+                        },
+                    },
+                },
+                new Circuit
+                {
+                    Name = "ChildCircuit",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                },
+            },
+        };
+
+        using var cascodeHome = CascodeHome.CreateInTemp("SpiceEmitterTest");
+        var tempDir = cascodeHome.Path;
+
+        var result = SpiceEmitter.Emit(doc, tempDir);
+
+        // Both circuits should be emitted
+        Assert.Equal(2, result.DesignPaths.Count);
+
+        // Check order of files: ChildCircuit should come before TopLevel
+        var childPath = result.DesignPaths.FirstOrDefault(p => p.Contains("ChildCircuit"));
+        var topPath = result.DesignPaths.FirstOrDefault(p => p.Contains("TopLevel"));
+        Assert.NotNull(childPath);
+        Assert.NotNull(topPath);
+
+        var childIndex = result.DesignPaths.IndexOf(childPath);
+        var topIndex = result.DesignPaths.IndexOf(topPath);
+        Assert.True(childIndex < topIndex, "Child circuit should be emitted before top-level");
+    }
+
+    [Fact]
+    public void Emit_MultiCircuitDocument_EmitsAllSubckts()
+    {
+        var doc = new ACIRDocument
+        {
+            VersionMajor = ACIRVersion.Major,
+            VersionMinor = ACIRVersion.Minor,
+            Circuits = new List<Circuit>
+            {
+                new Circuit
+                {
+                    Name = "CircuitA",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                },
+                new Circuit
+                {
+                    Name = "CircuitB",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                },
+                new Circuit
+                {
+                    Name = "CircuitC",
+                    Level = ACIRLevel.EL,
+                    Supplies = new List<string> { "VDD" },
+                    Grounds = new List<string> { "GND" },
+                },
+            },
+        };
+
+        using var cascodeHome = CascodeHome.CreateInTemp("SpiceEmitterTest");
+        var tempDir = cascodeHome.Path;
+
+        var result = SpiceEmitter.Emit(doc, tempDir);
+
+        Assert.Equal(3, result.DesignPaths.Count);
+        Assert.True(File.Exists(Path.Combine(tempDir, "CircuitA.sp")));
+        Assert.True(File.Exists(Path.Combine(tempDir, "CircuitB.sp")));
+        Assert.True(File.Exists(Path.Combine(tempDir, "CircuitC.sp")));
+    }
+
+    // Integration tests using golden files
+
+    [Fact]
+    public void GoldenFile_OTA5T_Hierarchical_ParsesCorrectly()
+    {
+        var repoRoot = TestPathUtilities.GetRepositoryRoot();
+        var acirPath = Path.Combine(
+            repoRoot,
+            "tests/golden/acir/hierarchy/OTA5T_Hierarchical.el.cir"
+        );
+
+        using var reader = File.OpenText(acirPath);
+        var doc = ACIRReader.Read(reader);
+
+        Assert.Equal(ACIRVersion.Major, doc.VersionMajor);
+        Assert.Equal(ACIRVersion.Minor, doc.VersionMinor);
+
+        // Should have 4 circuits: DiffPair, ActiveLoad, OTA5T_Hierarchical, CurrentMirror
+        Assert.Equal(4, doc.Circuits.Count);
+
+        // Verify traits
+        Assert.Equal(3, doc.Traits.Count);
+        Assert.Contains(doc.Traits, t => t.Name == "CurrentMirrorTrait");
+        Assert.Contains(doc.Traits, t => t.Name == "LoadBranch");
+        Assert.Contains(doc.Traits, t => t.Name == "DiffPairTrait");
+
+        // Verify inline circuits
+        var diffPair = doc.Circuits.First(c => c.Name == "DiffPair");
+        Assert.True(diffPair.Inline);
+        Assert.Contains("DiffPairTrait", diffPair.Traits!);
+
+        var activeLoad = doc.Circuits.First(c => c.Name == "ActiveLoad");
+        Assert.True(activeLoad.Inline);
+        Assert.Contains("LoadBranch", activeLoad.Traits!);
+
+        // Verify top-level circuit has instances
+        var topLevel = doc.Circuits.First(c => c.Name == "OTA5T_Hierarchical");
+        Assert.NotNull(topLevel.Fill);
+        Assert.Equal(3, topLevel.Fill.Instances.Count);
+        Assert.Contains(topLevel.Fill.Instances, i => i.Id == "dp" && i.Type == "DiffPair");
+        Assert.Contains(topLevel.Fill.Instances, i => i.Id == "cm" && i.Type == "CurrentMirror");
+        Assert.Contains(topLevel.Fill.Instances, i => i.Id == "load" && i.Type == "ActiveLoad");
+    }
+
+    [Fact]
+    public void GoldenFile_CurrentMirror_Standalone_ParsesCorrectly()
+    {
+        var repoRoot = TestPathUtilities.GetRepositoryRoot();
+        var acirPath = Path.Combine(
+            repoRoot,
+            "tests/golden/acir/hierarchy/CurrentMirror_Standalone.el.cir"
+        );
+
+        using var reader = File.OpenText(acirPath);
+        var doc = ACIRReader.Read(reader);
+
+        Assert.Single(doc.Circuits);
+        Assert.Single(doc.Traits);
+
+        var circuit = doc.Circuits[0];
+        Assert.Equal("CurrentMirror", circuit.Name);
+        Assert.Contains("CurrentMirrorTrait", circuit.Traits!);
+
+        // Verify parameters
+        Assert.Equal(3, circuit.Parameters.Count);
+        Assert.Contains(circuit.Parameters, p => p.Name == "ratio" && p.Default?.Numeric == "1");
+        Assert.Contains(circuit.Parameters, p => p.Name == "W" && p.Default?.Numeric == "2u");
+        Assert.Contains(circuit.Parameters, p => p.Name == "L" && p.Default?.Numeric == "180n");
+
+        // Verify devices
+        Assert.NotNull(circuit.Fill);
+        Assert.Equal(2, circuit.Fill.Devices.Count);
+    }
+
+    [Fact]
+    public void GoldenFile_OTA5T_Hierarchical_EmitsSpiceWithInlineExpansion()
+    {
+        var repoRoot = TestPathUtilities.GetRepositoryRoot();
+        var acirPath = Path.Combine(
+            repoRoot,
+            "tests/golden/acir/hierarchy/OTA5T_Hierarchical.el.cir"
+        );
+
+        using var reader = File.OpenText(acirPath);
+        var doc = ACIRReader.Read(reader);
+
+        var topLevel = doc.Circuits.First(c => c.Name == "OTA5T_Hierarchical");
+
+        using var writer = new StringWriter();
+        SpiceEmitter.EmitDesign(topLevel, writer, document: doc);
+        var output = writer.ToString();
+
+        // Inline circuits (DiffPair, ActiveLoad) should be expanded, not X-elements
+        Assert.DoesNotContain("Xdp ", output);
+        Assert.DoesNotContain("Xload ", output);
+
+        // Non-inline circuit (CurrentMirror) should emit as X-element
+        Assert.Contains("Xcm ", output);
+
+        // DiffPair inline expansion: devices should have dp__ prefix
+        Assert.Contains("Mdp__M_N", output);
+        Assert.Contains("Mdp__M_P", output);
+        Assert.Contains("Mdp__M_TAIL", output);
+
+        // ActiveLoad inline expansion
+        Assert.Contains("Mload__M_LOAD", output);
+
+        // Internal net from DiffPair should be uniquified
+        Assert.Contains("dp__tnode", output);
+    }
+
+    [Fact]
+    public void GoldenFile_OTA5T_Hierarchical_ValidatesSuccessfully()
+    {
+        var repoRoot = TestPathUtilities.GetRepositoryRoot();
+        var acirPath = Path.Combine(
+            repoRoot,
+            "tests/golden/acir/hierarchy/OTA5T_Hierarchical.el.cir"
+        );
+
+        using var reader = File.OpenText(acirPath);
+        var doc = ACIRReader.Read(reader);
+
+        var result = HierarchyValidator.Validate(doc);
+
+        Assert.True(
+            result.IsValid,
+            $"Validation failed: {string.Join(", ", result.GetErrors().Select(e => e.Message))}"
+        );
+    }
+
+    [Fact]
+    public void GoldenFile_OTA5T_Hierarchical_EmitProducesValidSubckts()
+    {
+        var repoRoot = TestPathUtilities.GetRepositoryRoot();
+        var acirPath = Path.Combine(
+            repoRoot,
+            "tests/golden/acir/hierarchy/OTA5T_Hierarchical.el.cir"
+        );
+
+        using var reader = File.OpenText(acirPath);
+        var doc = ACIRReader.Read(reader);
+
+        using var cascodeHome = CascodeHome.CreateInTemp("SpiceEmitterTest");
+        var tempDir = cascodeHome.Path;
+
+        // Emit each non-inline circuit manually
+        var designPaths = new List<string>();
+        foreach (var circuit in doc.Circuits.Where(c => !c.Inline))
+        {
+            var path = Path.Combine(tempDir, $"{circuit.Name}.sp");
+            using var writer = File.CreateText(path);
+            SpiceEmitter.EmitDesign(circuit, writer, document: doc);
+            designPaths.Add(path);
+        }
+
+        // Non-inline circuits should each produce a .sp file
+        // OTA5T_Hierarchical and CurrentMirror are non-inline
+        Assert.Contains(designPaths, p => p.Contains("OTA5T_Hierarchical.sp"));
+        Assert.Contains(designPaths, p => p.Contains("CurrentMirror.sp"));
+
+        // Read top-level file and verify structure
+        var topLevelPath = designPaths.First(p => p.Contains("OTA5T_Hierarchical.sp"));
+        var spiceContent = File.ReadAllText(topLevelPath);
+
+        // Should have subckt declaration
+        Assert.Contains(".subckt OTA5T_Hierarchical", spiceContent);
+        Assert.Contains(".ends OTA5T_Hierarchical", spiceContent);
+
+        // Should reference CurrentMirror as X-element
+        Assert.Contains("Xcm", spiceContent);
+        Assert.Contains("CurrentMirror", spiceContent);
+    }
+
+    [Fact]
+    public void GoldenFile_OTA5T_Hierarchical_TraitConnectorsPreserved()
+    {
+        var repoRoot = TestPathUtilities.GetRepositoryRoot();
+        var acirPath = Path.Combine(
+            repoRoot,
+            "tests/golden/acir/hierarchy/OTA5T_Hierarchical.el.cir"
+        );
+
+        using var reader = File.OpenText(acirPath);
+        var doc = ACIRReader.Read(reader);
+
+        // Verify trait connector was parsed correctly
+        var mirrorTrait = doc.Traits.First(t => t.Name == "CurrentMirrorTrait");
+        Assert.Single(mirrorTrait.Connectors);
+
+        var connector = mirrorTrait.Connectors[0];
+        Assert.Equal("LoadBranch", connector.TargetTrait);
+        Assert.Single(connector.Mappings);
+        Assert.Equal("OUT", connector.Mappings[0].SourcePort);
+        Assert.Equal("IN", connector.Mappings[0].TargetPort);
+    }
+
+    [Fact]
+    public void GoldenFile_RoundTrip_ParseWriteParseMatches()
+    {
+        var repoRoot = TestPathUtilities.GetRepositoryRoot();
+        var acirPath = Path.Combine(
+            repoRoot,
+            "tests/golden/acir/hierarchy/CurrentMirror_Standalone.el.cir"
+        );
+
+        using var reader = File.OpenText(acirPath);
+        var doc1 = ACIRReader.Read(reader);
+
+        // Write to string
+        using var writeBuffer = new StringWriter();
+        ACIRWriter.Write(doc1, writeBuffer);
+        var written = writeBuffer.ToString();
+
+        // Parse again
+        using var reader2 = new StringReader(written);
+        var doc2 = ACIRReader.Read(reader2);
+
+        // Verify structure matches
+        Assert.Equal(doc1.Circuits.Count, doc2.Circuits.Count);
+        Assert.Equal(doc1.Traits.Count, doc2.Traits.Count);
+
+        var c1 = doc1.Circuits[0];
+        var c2 = doc2.Circuits[0];
+
+        Assert.Equal(c1.Name, c2.Name);
+        Assert.Equal(c1.Traits?.Count, c2.Traits?.Count);
+        Assert.Equal(c1.Parameters.Count, c2.Parameters.Count);
+        Assert.Equal(c1.Fill?.Devices.Count, c2.Fill?.Devices.Count);
+    }
+}

--- a/tests/unit/tools/acir/Cascode.ACIR.Tests/SpiceEmitterTests.cs
+++ b/tests/unit/tools/acir/Cascode.ACIR.Tests/SpiceEmitterTests.cs
@@ -104,8 +104,8 @@ public class SpiceEmitterTests
         using var reader = File.OpenText(acirPath);
         var doc = ACIRReader.Read(reader);
 
-        Assert.Equal(2, doc.VersionMajor);
-        Assert.Equal(0, doc.VersionMinor);
+        Assert.Equal(ACIRVersion.Major, doc.VersionMajor);
+        Assert.Equal(ACIRVersion.Minor, doc.VersionMinor);
         Assert.Single(doc.Circuits);
 
         var circuit = doc.Circuits[0];

--- a/tools/acir/ACIRDocument.cs
+++ b/tools/acir/ACIRDocument.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Cascode.ACIR;
 
@@ -496,7 +498,7 @@ public sealed class TraitConnector
 /// <summary>
 /// A single port-to-port mapping in a connector.
 /// </summary>
-public sealed class ConnectorMapping
+public sealed record ConnectorMapping
 {
     /// <summary>Source port (on the trait defining the connector).</summary>
     public required string SourcePort { get; init; }
@@ -508,13 +510,13 @@ public sealed class ConnectorMapping
 /// <summary>
 /// Attach statement for trait-based composition at EL level.
 /// </summary>
-public sealed class AttachStatement
+public sealed record AttachStatement
 {
     /// <summary>Source instance identifier.</summary>
     public required string SourceInstance { get; init; }
 
-    /// <summary>Target instance identifier.</summary>
-    public required string TargetInstance { get; init; }
+    /// <summary>Target instance identifiers (in chain order).</summary>
+    public required IReadOnlyList<string> TargetInstances { get; init; }
 
     /// <summary>Connector reference in "TraitName::TargetTrait" format.</summary>
     public required string Via { get; init; }
@@ -523,5 +525,66 @@ public sealed class AttachStatement
     public string? Anchor { get; init; }
 
     /// <summary>Optional inline override mappings.</summary>
-    public List<ConnectorMapping>? Overrides { get; init; }
+    public IReadOnlyList<ConnectorMapping>? Overrides { get; init; }
+
+    /// <inheritdoc />
+    public bool Equals(AttachStatement? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        if (ReferenceEquals(this, other))
+        {
+            return true;
+        }
+
+        return string.Equals(SourceInstance, other.SourceInstance, StringComparison.Ordinal)
+            && string.Equals(Via, other.Via, StringComparison.Ordinal)
+            && string.Equals(Anchor, other.Anchor, StringComparison.Ordinal)
+            && TargetInstances.SequenceEqual(other.TargetInstances, StringComparer.Ordinal)
+            && OverridesEqual(Overrides, other.Overrides);
+    }
+
+    /// <inheritdoc />
+    public override int GetHashCode()
+    {
+        var hash = new HashCode();
+        hash.Add(SourceInstance, StringComparer.Ordinal);
+        hash.Add(Via, StringComparer.Ordinal);
+        hash.Add(Anchor, StringComparer.Ordinal);
+        foreach (var target in TargetInstances)
+        {
+            hash.Add(target, StringComparer.Ordinal);
+        }
+
+        if (Overrides is not null)
+        {
+            foreach (var mapping in Overrides)
+            {
+                hash.Add(mapping);
+            }
+        }
+
+        return hash.ToHashCode();
+    }
+
+    private static bool OverridesEqual(
+        IReadOnlyList<ConnectorMapping>? left,
+        IReadOnlyList<ConnectorMapping>? right
+    )
+    {
+        if (left is null && right is null)
+        {
+            return true;
+        }
+
+        if (left is null || right is null)
+        {
+            return false;
+        }
+
+        return left.SequenceEqual(right);
+    }
 }

--- a/tools/acir/ACIRReader.cs
+++ b/tools/acir/ACIRReader.cs
@@ -663,6 +663,19 @@ public static partial class ACIRReader
             {
                 if (currentFill is not null)
                 {
+                    if (contentTrimmed.StartsWith("attach "))
+                    {
+                        var (attach, nextIndex) = ParseAttachWithOverrides(
+                            lines,
+                            i,
+                            filePath,
+                            diagnostics
+                        );
+                        if (attach is not null)
+                            currentFill.Attaches.Add(attach);
+                        i = nextIndex;
+                        continue;
+                    }
                     ParseFillContentWithDiagnostics(
                         contentTrimmed,
                         currentFill,
@@ -763,7 +776,25 @@ public static partial class ACIRReader
             else if (contentTrimmed.StartsWith("level "))
             {
                 var levelStr = contentTrimmed[6..].Trim();
-                level = ParseLevel(levelStr);
+                var parsedLevel = TryParseLevel(levelStr);
+                if (parsedLevel.HasValue)
+                {
+                    level = parsedLevel.Value;
+                }
+                else
+                {
+                    // No fallback: the error diagnostic causes Success=false, so callers
+                    // must not use the document. The initialized value of 'level' is irrelevant.
+                    diagnostics.Add(
+                        new Diagnostic(
+                            $"ACIR0008: Invalid level '{levelStr}' - expected HL, ML, or EL",
+                            DiagnosticSeverity.Error,
+                            filePath,
+                            i + 1,
+                            1
+                        )
+                    );
+                }
             }
             else if (contentTrimmed.StartsWith("supply "))
             {
@@ -803,7 +834,7 @@ public static partial class ACIRReader
                     if (paramMatch.Groups[3].Success)
                     {
                         var defaultStr = paramMatch.Groups[3].Value.Trim();
-                        defaultValue = ParseParamValue(defaultStr);
+                        defaultValue = ParamValueParser.Parse(defaultStr);
                     }
 
                     parameters.Add(
@@ -895,12 +926,6 @@ public static partial class ACIRReader
             if (instance is not null)
                 fill.Instances.Add(instance);
         }
-        else if (line.StartsWith("attach "))
-        {
-            var attach = ParseAttachWithDiagnostics(line, filePath, lineNumber, diagnostics);
-            if (attach is not null)
-                fill.Attaches.Add(attach);
-        }
     }
 
     /// <summary>
@@ -953,43 +978,182 @@ public static partial class ACIRReader
     }
 
     /// <summary>
-    /// Parses an attach statement with diagnostic collection.
+    /// Parses an attach statement, including optional inline override blocks.
     /// </summary>
-    private static AttachStatement? ParseAttachWithDiagnostics(
-        string line,
+    private static (AttachStatement? Attach, int NextIndex) ParseAttachWithOverrides(
+        IReadOnlyList<string> lines,
+        int startIndex,
         string filePath,
-        int lineNumber,
-        List<Diagnostic> diagnostics
+        List<Diagnostic>? diagnostics
     )
     {
-        var match = AttachStatementPattern().Match(line);
+        string StripComment(string value)
+        {
+            var commentIndex = value.IndexOf("//", StringComparison.Ordinal);
+            return commentIndex >= 0 ? value[..commentIndex] : value;
+        }
+
+        var lineNumber = startIndex + 1;
+        var rawLine = StripComment(lines[startIndex]).Trim();
+        var braceIndex = rawLine.IndexOf('{');
+        var headerLine = braceIndex >= 0 ? rawLine[..braceIndex].TrimEnd() : rawLine;
+        var afterBrace = braceIndex >= 0 ? rawLine[(braceIndex + 1)..].Trim() : string.Empty;
+        var hasOpeningBrace = braceIndex >= 0;
+        var inlineOverrides =
+            hasOpeningBrace && afterBrace.EndsWith("}", StringComparison.Ordinal)
+                ? afterBrace[..^1].Trim()
+                : afterBrace;
+
+        var match = AttachStatementPattern().Match(headerLine);
         if (!match.Success)
         {
-            diagnostics.Add(
-                new Diagnostic(
-                    $"ACIR0016: Invalid attach statement syntax '{line}'",
-                    DiagnosticSeverity.Error,
-                    filePath,
-                    lineNumber,
-                    1
-                )
-            );
-            return null;
+            if (diagnostics is not null)
+            {
+                diagnostics.Add(
+                    new Diagnostic(
+                        $"ACIR0016: Invalid attach statement syntax '{rawLine}'",
+                        DiagnosticSeverity.Error,
+                        filePath,
+                        lineNumber,
+                        1
+                    )
+                );
+            }
+            return (null, startIndex + 1);
         }
 
         var sourceInstance = match.Groups[1].Value;
-        var targetInstance = match.Groups[2].Value;
+        var targetSegment = match.Groups[2].Value;
         var sourceTrait = match.Groups[3].Value;
         var targetTrait = match.Groups[4].Value;
         var anchor = match.Groups[5].Success ? match.Groups[5].Value : null;
 
-        return new AttachStatement
+        var targetInstances = targetSegment
+            .Split(new[] { " to " }, StringSplitOptions.RemoveEmptyEntries)
+            .Select(s => s.Trim())
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .ToList();
+        if (targetInstances.Count == 0)
         {
-            SourceInstance = sourceInstance,
-            TargetInstance = targetInstance,
-            Via = $"{sourceTrait}::{targetTrait}",
-            Anchor = anchor,
-        };
+            if (diagnostics is not null)
+            {
+                diagnostics.Add(
+                    new Diagnostic(
+                        $"ACIR0016: Invalid attach statement syntax '{rawLine}'",
+                        DiagnosticSeverity.Error,
+                        filePath,
+                        lineNumber,
+                        1
+                    )
+                );
+            }
+            return (null, startIndex + 1);
+        }
+
+        List<ConnectorMapping>? overrides = null;
+
+        void AddOverride(string mappingLine, int mappingLineNumber)
+        {
+            var mappingMatch = ConnectorMappingPattern().Match(mappingLine);
+            if (mappingMatch.Success)
+            {
+                overrides ??= new List<ConnectorMapping>();
+                overrides.Add(
+                    new ConnectorMapping
+                    {
+                        SourcePort = mappingMatch.Groups[1].Value,
+                        TargetPort = mappingMatch.Groups[2].Value,
+                    }
+                );
+            }
+            else if (diagnostics is not null)
+            {
+                diagnostics.Add(
+                    new Diagnostic(
+                        $"ACIR0016: Invalid attach override syntax '{mappingLine}'",
+                        DiagnosticSeverity.Error,
+                        filePath,
+                        mappingLineNumber,
+                        1
+                    )
+                );
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(inlineOverrides))
+        {
+            AddOverride(inlineOverrides, lineNumber);
+        }
+
+        if (hasOpeningBrace && !afterBrace.EndsWith("}", StringComparison.Ordinal))
+        {
+            var i = startIndex + 1;
+            while (i < lines.Count)
+            {
+                var content = StripComment(lines[i]);
+                var trimmed = content.Trim();
+                if (string.IsNullOrWhiteSpace(trimmed))
+                {
+                    i++;
+                    continue;
+                }
+
+                if (trimmed == "}")
+                {
+                    return (
+                        new AttachStatement
+                        {
+                            SourceInstance = sourceInstance,
+                            TargetInstances = targetInstances,
+                            Via = $"{sourceTrait}::{targetTrait}",
+                            Anchor = anchor,
+                            Overrides = overrides,
+                        },
+                        i + 1
+                    );
+                }
+
+                AddOverride(trimmed, i + 1);
+                i++;
+            }
+
+            if (diagnostics is not null)
+            {
+                diagnostics.Add(
+                    new Diagnostic(
+                        "ACIR0016: Unterminated attach override block",
+                        DiagnosticSeverity.Error,
+                        filePath,
+                        lineNumber,
+                        1
+                    )
+                );
+            }
+
+            return (
+                new AttachStatement
+                {
+                    SourceInstance = sourceInstance,
+                    TargetInstances = targetInstances,
+                    Via = $"{sourceTrait}::{targetTrait}",
+                    Anchor = anchor,
+                    Overrides = overrides,
+                },
+                lines.Count
+            );
+        }
+
+        return (
+            new AttachStatement
+            {
+                SourceInstance = sourceInstance,
+                TargetInstances = targetInstances,
+                Via = $"{sourceTrait}::{targetTrait}",
+                Anchor = anchor,
+                Overrides = overrides,
+            },
+            startIndex + 1
+        );
     }
 
     /// <summary>
@@ -1211,6 +1375,19 @@ public static partial class ACIRReader
             {
                 if (currentFill is not null)
                 {
+                    if (contentTrimmed.StartsWith("attach "))
+                    {
+                        var (attach, nextIndex) = ParseAttachWithOverrides(
+                            lines,
+                            i,
+                            string.Empty,
+                            null
+                        );
+                        if (attach is not null)
+                            currentFill.Attaches.Add(attach);
+                        i = nextIndex;
+                        continue;
+                    }
                     ParseFillContent(contentTrimmed, currentFill);
                 }
                 else if (currentHarness is not null)
@@ -1299,7 +1476,7 @@ public static partial class ACIRReader
             else if (contentTrimmed.StartsWith("level "))
             {
                 var levelStr = contentTrimmed[6..].Trim();
-                level = ParseLevel(levelStr);
+                level = TryParseLevel(levelStr) ?? ACIRLevel.ML;
             }
             else if (contentTrimmed.StartsWith("supply "))
             {
@@ -1339,7 +1516,7 @@ public static partial class ACIRReader
                     if (paramMatch.Groups[3].Success)
                     {
                         var defaultStr = paramMatch.Groups[3].Value.Trim();
-                        defaultValue = ParseParamValue(defaultStr);
+                        defaultValue = ParamValueParser.Parse(defaultStr);
                     }
 
                     parameters.Add(
@@ -1553,12 +1730,6 @@ public static partial class ACIRReader
             if (instance is not null)
                 fill.Instances.Add(instance);
         }
-        else if (line.StartsWith("attach "))
-        {
-            var attach = ParseAttach(line);
-            if (attach is not null)
-                fill.Attaches.Add(attach);
-        }
     }
 
     /// <summary>
@@ -1650,54 +1821,6 @@ public static partial class ACIRReader
             Type = type,
             Bindings = bindings,
         };
-    }
-
-    /// <summary>
-    /// Parses an attach statement line.
-    /// </summary>
-    /// <param name="line">Attach statement line.</param>
-    /// <returns>Parsed attach statement, or null if the line doesn't match.</returns>
-    private static AttachStatement? ParseAttach(string line)
-    {
-        var match = AttachStatementPattern().Match(line);
-        if (!match.Success)
-            return null;
-
-        var sourceInstance = match.Groups[1].Value;
-        var targetInstance = match.Groups[2].Value;
-        var sourceTrait = match.Groups[3].Value;
-        var targetTrait = match.Groups[4].Value;
-        var anchor = match.Groups[5].Success ? match.Groups[5].Value : null;
-
-        return new AttachStatement
-        {
-            SourceInstance = sourceInstance,
-            TargetInstance = targetInstance,
-            Via = $"{sourceTrait}::{targetTrait}",
-            Anchor = anchor,
-        };
-    }
-
-    /// <summary>
-    /// Parses a parameter value string into a ParamValue object.
-    /// </summary>
-    /// <param name="value">The value string to parse.</param>
-    /// <returns>A ParamValue with the appropriate field set.</returns>
-    private static ParamValue ParseParamValue(string value)
-    {
-        if (value.StartsWith('$'))
-        {
-            return new ParamValue { Symbolic = value };
-        }
-
-        // Check if it's a numeric value (digits, decimal point, or SI suffix)
-        if (NumericValuePattern().IsMatch(value))
-        {
-            return new ParamValue { Numeric = value };
-        }
-
-        // Otherwise treat as literal
-        return new ParamValue { Literal = value };
     }
 
     /// <summary>
@@ -2054,15 +2177,15 @@ public static partial class ACIRReader
     /// Parses an ACIR level string (HL, ML, or EL) into the corresponding enum value.
     /// </summary>
     /// <param name="level">Level string.</param>
-    /// <returns>Parsed ACIR level, defaulting to ML if unrecognized.</returns>
-    private static ACIRLevel ParseLevel(string level)
+    /// <returns>Parsed ACIR level, or null if unrecognized.</returns>
+    private static ACIRLevel? TryParseLevel(string level)
     {
         return level.ToUpperInvariant() switch
         {
             "HL" => ACIRLevel.HL,
             "ML" => ACIRLevel.ML,
             "EL" => ACIRLevel.EL,
-            _ => ACIRLevel.ML,
+            _ => null,
         };
     }
 
@@ -2145,12 +2268,11 @@ public static partial class ACIRReader
     [GeneratedRegex(@"^param\s+(\w+)\s*:\s*(\w+)(?:\s*=\s*(.+))?$")]
     private static partial Regex CircuitParameterPattern();
 
-    [GeneratedRegex(@"^-?\d+\.?\d*[fpnumkMGT]?[A-Za-z]*$")]
-    private static partial Regex NumericValuePattern();
-
     [GeneratedRegex(@"^inst\s+(\w+)\s*(?:\(([^)]*)\))?\s*:\s*(\w+)")]
     private static partial Regex InstanceDeclarationPattern();
 
-    [GeneratedRegex(@"^attach\s+(\w+)\s+to\s+(\w+)\s+via\s+(\w+)::(\w+)(?:\s+as\s+(\w+))?$")]
+    [GeneratedRegex(
+        @"^attach\s+(\w+)((?:\s+to\s+\w+)+)\s+via\s+(\w+)::(\w+)(?:\s+as\s+(\w+))?(?:\s*\{)?$"
+    )]
     private static partial Regex AttachStatementPattern();
 }

--- a/tools/acir/ACIRWriter.cs
+++ b/tools/acir/ACIRWriter.cs
@@ -241,21 +241,32 @@ public static class ACIRWriter
     private static void WriteAttach(AttachStatement attach, TextWriter writer)
     {
         var viaParts = attach.Via.Split("::");
-        var header =
-            $"    attach {attach.SourceInstance} to {attach.TargetInstance} via {viaParts[0]}::{viaParts[1]}";
+        var header = new StringBuilder();
+        header.Append($"    attach {attach.SourceInstance}");
+        foreach (var target in attach.TargetInstances)
+        {
+            header.Append($" to {target}");
+        }
+        header.Append($" via {viaParts[0]}::{viaParts[1]}");
         if (!string.IsNullOrEmpty(attach.Anchor))
         {
-            header += $" as {attach.Anchor}";
+            header.Append($" as {attach.Anchor}");
         }
-        writer.WriteLine(header);
 
-        // Inline overrides if present
         if (attach.Overrides is { Count: > 0 })
         {
-            foreach (var mapping in attach.Overrides)
+            writer.WriteLine($"{header} {{");
+            foreach (
+                var mapping in attach.Overrides.OrderBy(m => m.SourcePort, StringComparer.Ordinal)
+            )
             {
                 writer.WriteLine($"      {mapping.SourcePort} -> {mapping.TargetPort}");
             }
+            writer.WriteLine("    }");
+        }
+        else
+        {
+            writer.WriteLine(header.ToString());
         }
     }
 

--- a/tools/acir/AttachResolutionResult.cs
+++ b/tools/acir/AttachResolutionResult.cs
@@ -1,0 +1,91 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Cascode.Parser;
+
+namespace Cascode.ACIR;
+
+/// <summary>
+/// Result of attach resolution for the entire document.
+/// </summary>
+public sealed class AttachResolutionResult
+{
+    internal readonly Dictionary<string, CircuitResolutionResult> _circuitResults = new();
+    internal readonly List<Diagnostic> _diagnostics = new();
+
+    /// <summary>
+    /// Resolution results per circuit.
+    /// </summary>
+    public IReadOnlyDictionary<string, CircuitResolutionResult> CircuitResults { get; }
+
+    /// <summary>
+    /// All diagnostics from resolution.
+    /// </summary>
+    public IReadOnlyList<Diagnostic> Diagnostics { get; }
+
+    /// <summary>
+    /// Whether resolution completed without errors.
+    /// </summary>
+    public bool Success => !_diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error);
+
+    public AttachResolutionResult()
+    {
+        CircuitResults = new ReadOnlyDictionary<string, CircuitResolutionResult>(_circuitResults);
+        Diagnostics = _diagnostics.AsReadOnly();
+    }
+}
+
+/// <summary>
+/// Result of attach resolution for a single circuit.
+/// </summary>
+public sealed class CircuitResolutionResult
+{
+    internal readonly Dictionary<string, string> _netToRepresentative = new();
+    internal readonly Dictionary<string, IReadOnlyList<string>> _netEquivalences = new();
+    internal readonly Dictionary<string, string> _terminalToNet = new();
+    internal readonly Dictionary<
+        AttachStatement,
+        IReadOnlyDictionary<string, string>
+    > _attachBindings = new();
+    internal readonly List<Diagnostic> _diagnostics = new();
+
+    /// <summary>
+    /// Maps each net to its representative in the equivalence class.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> NetToRepresentative { get; }
+
+    /// <summary>
+    /// Maps representative nets to all nets in their equivalence class.
+    /// </summary>
+    public IReadOnlyDictionary<string, IReadOnlyList<string>> NetEquivalences { get; }
+
+    /// <summary>
+    /// Maps terminal endpoints to their resolved net names.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> TerminalToNet { get; }
+
+    /// <summary>
+    /// Maps attach statements to the generated port bindings.
+    /// </summary>
+    public IReadOnlyDictionary<
+        AttachStatement,
+        IReadOnlyDictionary<string, string>
+    > AttachBindings { get; }
+
+    /// <summary>
+    /// Diagnostics for this circuit's resolution.
+    /// </summary>
+    public IReadOnlyList<Diagnostic> Diagnostics { get; }
+
+    public CircuitResolutionResult()
+    {
+        NetToRepresentative = new ReadOnlyDictionary<string, string>(_netToRepresentative);
+        NetEquivalences = new ReadOnlyDictionary<string, IReadOnlyList<string>>(_netEquivalences);
+        TerminalToNet = new ReadOnlyDictionary<string, string>(_terminalToNet);
+        AttachBindings = new ReadOnlyDictionary<
+            AttachStatement,
+            IReadOnlyDictionary<string, string>
+        >(_attachBindings);
+        Diagnostics = _diagnostics.AsReadOnly();
+    }
+}

--- a/tools/acir/AttachResolver.Attach.cs
+++ b/tools/acir/AttachResolver.Attach.cs
@@ -1,0 +1,428 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cascode.Parser;
+
+namespace Cascode.ACIR;
+
+public sealed partial class AttachResolver
+{
+    private void ApplyAttachStatements(
+        Circuit circuit,
+        ResolutionContext context,
+        List<Diagnostic> diagnostics
+    )
+    {
+        if (circuit.Fill!.Attaches.Count == 0)
+        {
+            return;
+        }
+
+        var instancesById = circuit.Fill.Instances.ToDictionary(
+            inst => inst.Id,
+            StringComparer.Ordinal
+        );
+
+        for (var attachIndex = 0; attachIndex < circuit.Fill.Attaches.Count; attachIndex++)
+        {
+            var attach = circuit.Fill.Attaches[attachIndex];
+            var attachInfo = ResolveConnector(attach, circuit, diagnostics);
+            if (attachInfo is null)
+            {
+                continue;
+            }
+
+            context.ConnectorByAttach[attach] = attachInfo;
+            ProcessAttach(
+                circuit,
+                attach,
+                attachInfo,
+                attachIndex,
+                instancesById,
+                context,
+                diagnostics
+            );
+        }
+    }
+
+    private AttachResolutionInfo? ResolveConnector(
+        AttachStatement attach,
+        Circuit circuit,
+        List<Diagnostic> diagnostics
+    )
+    {
+        var viaParts = attach.Via.Split("::");
+        if (viaParts.Length != 2)
+        {
+            diagnostics.Add(
+                new Diagnostic(
+                    $"ACIR0022: Malformed via clause '{attach.Via}'",
+                    DiagnosticSeverity.Error,
+                    circuit.Name,
+                    1,
+                    1
+                )
+            );
+            return null;
+        }
+
+        var sourceTraitName = viaParts[0];
+        var targetTraitName = viaParts[1];
+
+        if (!_traitsByName.TryGetValue(sourceTraitName, out var sourceTrait))
+        {
+            diagnostics.Add(
+                new Diagnostic(
+                    $"ACIR0021: Undefined trait '{sourceTraitName}' in attach via clause",
+                    DiagnosticSeverity.Error,
+                    circuit.Name,
+                    1,
+                    1
+                )
+            );
+            return null;
+        }
+
+        var connector = sourceTrait.Connectors.FirstOrDefault(c =>
+            c.TargetTrait.Equals(targetTraitName, StringComparison.Ordinal)
+        );
+        if (connector is null)
+        {
+            diagnostics.Add(
+                new Diagnostic(
+                    $"ACIR0023: No connector from '{sourceTraitName}' to '{targetTraitName}'",
+                    DiagnosticSeverity.Error,
+                    circuit.Name,
+                    1,
+                    1
+                )
+            );
+            return null;
+        }
+
+        _traitsByName.TryGetValue(targetTraitName, out var targetTrait);
+
+        return new AttachResolutionInfo(connector, sourceTrait, targetTrait);
+    }
+
+    private void ProcessAttach(
+        Circuit circuit,
+        AttachStatement attach,
+        AttachResolutionInfo attachInfo,
+        int attachIndex,
+        Dictionary<string, InstanceDeclaration> instancesById,
+        ResolutionContext context,
+        List<Diagnostic> diagnostics
+    )
+    {
+        var connector = attachInfo.Connector;
+        var sourceTrait = attachInfo.SourceTrait;
+        var targetTrait = attachInfo.TargetTrait;
+
+        var createdAutoNets = new List<string>();
+        var instanceChain = BuildInstanceChain(attach);
+
+        // Validate override source ports exist in connector
+        if (attach.Overrides is { Count: > 0 })
+        {
+            var connectorSourcePorts = connector
+                .Mappings.Select(m => m.SourcePort)
+                .ToHashSet(StringComparer.Ordinal);
+
+            foreach (var ov in attach.Overrides)
+            {
+                if (!connectorSourcePorts.Contains(ov.SourcePort))
+                {
+                    diagnostics.Add(
+                        new Diagnostic(
+                            $"Override source port '{ov.SourcePort}' not found in connector {attach.Via}",
+                            DiagnosticSeverity.Warning,
+                            circuit.Name,
+                            1,
+                            1
+                        )
+                    );
+                }
+            }
+        }
+
+        // Validate domain compatibility based on trait port definitions
+        foreach (var (sourcePort, targetPort) in EnumerateConnectorMappings(attach, connector))
+        {
+            var sourcePortDomain =
+                sourceTrait?.Ports.FirstOrDefault(p => p.Name == sourcePort)?.Type ?? DefaultDomain;
+            var targetPortDomain =
+                targetTrait?.Ports.FirstOrDefault(p => p.Name == targetPort)?.Type ?? DefaultDomain;
+
+            if (!string.Equals(sourcePortDomain, targetPortDomain, StringComparison.Ordinal))
+            {
+                diagnostics.Add(
+                    new Diagnostic(
+                        $"ACIR0024: Domain mismatch in attach: {sourcePort} ({sourcePortDomain}) vs {targetPort} ({targetPortDomain})",
+                        DiagnosticSeverity.Error,
+                        circuit.Name,
+                        1,
+                        1
+                    )
+                );
+            }
+        }
+
+        for (var pairIndex = 0; pairIndex < instanceChain.Count - 1; pairIndex++)
+        {
+            var fromInstance = instanceChain[pairIndex];
+            var toInstance = instanceChain[pairIndex + 1];
+
+            foreach (var (sourcePort, targetPort) in EnumerateConnectorMappings(attach, connector))
+            {
+                ProcessAttachMapping(
+                    circuit,
+                    attachIndex,
+                    createdAutoNets,
+                    instancesById,
+                    context,
+                    diagnostics,
+                    fromInstance,
+                    toInstance,
+                    sourcePort,
+                    targetPort
+                );
+            }
+        }
+
+        ApplyAnchorNames(attach, createdAutoNets, context);
+    }
+
+    private void ProcessAttachMapping(
+        Circuit circuit,
+        int attachIndex,
+        List<string> createdAutoNets,
+        Dictionary<string, InstanceDeclaration> instancesById,
+        ResolutionContext context,
+        List<Diagnostic> diagnostics,
+        string fromInstance,
+        string toInstance,
+        string sourcePort,
+        string targetPort
+    )
+    {
+        var fromEndpoint = EnsureAttachEndpoint(instancesById, fromInstance, sourcePort, context);
+        var toEndpoint = EnsureAttachEndpoint(instancesById, toInstance, targetPort, context);
+
+        if (HasExplicitNetConflict(context, fromEndpoint, toEndpoint, out var conflict))
+        {
+            diagnostics.Add(
+                new Diagnostic(
+                    $"ACIR0020: Attach would merge distinct named nets '{conflict.FromNet}' and '{conflict.ToNet}'; use explicit 'connect' to unify",
+                    DiagnosticSeverity.Error,
+                    circuit.Name,
+                    1,
+                    1
+                )
+            );
+            return;
+        }
+
+        if (ShouldCreateAutoNet(context, fromEndpoint, toEndpoint))
+        {
+            CreateAutoNetOrReportDiagnostic(
+                circuit,
+                attachIndex,
+                createdAutoNets,
+                context,
+                diagnostics,
+                fromEndpoint,
+                toEndpoint
+            );
+            return;
+        }
+
+        TryUnion(context, fromEndpoint, toEndpoint, diagnostics, circuit.Name);
+    }
+
+    private static void CreateAutoNetOrReportDiagnostic(
+        Circuit circuit,
+        int attachIndex,
+        List<string> createdAutoNets,
+        ResolutionContext context,
+        List<Diagnostic> diagnostics,
+        string fromEndpoint,
+        string toEndpoint
+    )
+    {
+        var domain = context.DomainByRoot[context.UnionFind.Find(fromEndpoint)];
+        if (!TryEnsureDomainMatch(domain, toEndpoint, context, diagnostics, circuit.Name))
+        {
+            return;
+        }
+
+        if (domain is PowerDomain or GroundDomain)
+        {
+            diagnostics.Add(
+                new Diagnostic(
+                    "ACIR0025: Cannot auto-create supply/ground net; bind rails explicitly",
+                    DiagnosticSeverity.Error,
+                    circuit.Name,
+                    1,
+                    1
+                )
+            );
+            return;
+        }
+
+        var autoNetId = $"__auto_attach{attachIndex}_net{createdAutoNets.Count}";
+        AddAutoNetNode(context, autoNetId, domain);
+        createdAutoNets.Add(autoNetId);
+        TryUnion(context, fromEndpoint, autoNetId, diagnostics, circuit.Name);
+        TryUnion(context, toEndpoint, autoNetId, diagnostics, circuit.Name);
+    }
+
+    private static bool TryEnsureDomainMatch(
+        string expectedDomain,
+        string node,
+        ResolutionContext context,
+        List<Diagnostic> diagnostics,
+        string circuitName
+    )
+    {
+        var nodeDomain = context.DomainByRoot[context.UnionFind.Find(node)];
+        if (string.Equals(expectedDomain, nodeDomain, StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        diagnostics.Add(
+            new Diagnostic(
+                $"ACIR0024: Incompatible domain merge '{expectedDomain}' -> '{nodeDomain}'",
+                DiagnosticSeverity.Error,
+                circuitName,
+                1,
+                1
+            )
+        );
+        return false;
+    }
+
+    private static void ApplyAnchorNames(
+        AttachStatement attach,
+        List<string> autoNets,
+        ResolutionContext context
+    )
+    {
+        if (attach.Anchor is null || autoNets.Count == 0)
+        {
+            return;
+        }
+
+        if (autoNets.Count == 1)
+        {
+            context.AutoNetNameOverrides[autoNets[0]] = attach.Anchor;
+            return;
+        }
+
+        for (var index = 0; index < autoNets.Count; index++)
+        {
+            context.AutoNetNameOverrides[autoNets[index]] = $"{attach.Anchor}_{index}";
+        }
+    }
+
+    private bool HasExplicitNetConflict(
+        ResolutionContext context,
+        string fromEndpoint,
+        string toEndpoint,
+        out (string FromNet, string ToNet) conflict
+    )
+    {
+        conflict = default;
+        var fromRoot = context.UnionFind.Find(fromEndpoint);
+        var toRoot = context.UnionFind.Find(toEndpoint);
+        if (fromRoot == toRoot)
+        {
+            return false;
+        }
+
+        if (!HasExplicitNet(context, fromRoot) || !HasExplicitNet(context, toRoot))
+        {
+            return false;
+        }
+
+        var fromNet = context.ExplicitNetNamesByRoot[fromRoot].Min!;
+        var toNet = context.ExplicitNetNamesByRoot[toRoot].Min!;
+        conflict = (fromNet, toNet);
+        return true;
+    }
+
+    private static bool ShouldCreateAutoNet(
+        ResolutionContext context,
+        string fromEndpoint,
+        string toEndpoint
+    )
+    {
+        var fromRoot = context.UnionFind.Find(fromEndpoint);
+        var toRoot = context.UnionFind.Find(toEndpoint);
+        return !HasNet(context, fromRoot) && !HasNet(context, toRoot);
+    }
+
+    private static bool HasNet(ResolutionContext context, string root)
+    {
+        return context.NetCountByRoot.TryGetValue(root, out var count) && count > 0;
+    }
+
+    private static bool HasExplicitNet(ResolutionContext context, string root)
+    {
+        return context.ExplicitNetNamesByRoot.TryGetValue(root, out var names) && names.Count > 0;
+    }
+
+    private string EnsureAttachEndpoint(
+        Dictionary<string, InstanceDeclaration> instancesById,
+        string instanceId,
+        string terminalPath,
+        ResolutionContext context
+    )
+    {
+        var endpointId = $"{instanceId}.{terminalPath}";
+        if (context.UnionFind.Contains(endpointId))
+        {
+            return endpointId;
+        }
+
+        if (instancesById.TryGetValue(instanceId, out var instance))
+        {
+            EnsureEndpointNode(instance, terminalPath, endpointId, context);
+            return endpointId;
+        }
+
+        AddEndpointNode(context, endpointId, DefaultDomain);
+        return endpointId;
+    }
+
+    private static IEnumerable<(string SourcePort, string TargetPort)> EnumerateConnectorMappings(
+        AttachStatement attach,
+        TraitConnector connector
+    )
+    {
+        Dictionary<string, string>? overrides = null;
+        if (attach.Overrides is { Count: > 0 })
+        {
+            overrides = attach.Overrides.ToDictionary(
+                mapping => mapping.SourcePort,
+                mapping => mapping.TargetPort,
+                StringComparer.Ordinal
+            );
+        }
+
+        foreach (var mapping in connector.Mappings)
+        {
+            var targetPort = mapping.TargetPort;
+            if (
+                overrides is not null
+                && overrides.TryGetValue(mapping.SourcePort, out var overridePort)
+            )
+            {
+                targetPort = overridePort;
+            }
+
+            yield return (mapping.SourcePort, targetPort);
+        }
+    }
+}

--- a/tools/acir/AttachResolver.Context.cs
+++ b/tools/acir/AttachResolver.Context.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+
+namespace Cascode.ACIR;
+
+public sealed partial class AttachResolver
+{
+    private sealed record AttachResolutionInfo(
+        TraitConnector Connector,
+        TraitDefinition? SourceTrait,
+        TraitDefinition? TargetTrait
+    );
+
+    private sealed class ResolutionContext
+    {
+        public UnionFind<string> UnionFind { get; } = new();
+        public Dictionary<string, string> NodeDomains { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, string> DomainByRoot { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, int> NetCountByRoot { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, SortedSet<string>> ExplicitNetNamesByRoot { get; } =
+            new(StringComparer.Ordinal);
+        public Dictionary<string, NetTier> NetTiers { get; } = new(StringComparer.Ordinal);
+        public HashSet<string> NetNodes { get; } = new(StringComparer.Ordinal);
+        public HashSet<string> ExplicitNetNodes { get; } = new(StringComparer.Ordinal);
+        public HashSet<string> EndpointNodes { get; } = new(StringComparer.Ordinal);
+        public Dictionary<string, string> AutoNetNameOverrides { get; } =
+            new(StringComparer.Ordinal);
+        public Dictionary<AttachStatement, AttachResolutionInfo> ConnectorByAttach { get; } = new();
+    }
+
+    private enum NetTier
+    {
+        Supply = 0,
+        Ground = 0,
+        PortExpansion = 1,
+        Declared = 2,
+    }
+}

--- a/tools/acir/AttachResolver.Finalize.cs
+++ b/tools/acir/AttachResolver.Finalize.cs
@@ -1,0 +1,268 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+
+namespace Cascode.ACIR;
+
+public sealed partial class AttachResolver
+{
+    private void FinalizeResolution(ResolutionContext context, CircuitResolutionResult result)
+    {
+        var netNodesByRoot = GroupNodesByRoot(context.NetNodes, context);
+        var endpointNodesByRoot = GroupNodesByRoot(context.EndpointNodes, context);
+        var representatives = DetermineRepresentatives(
+            context,
+            netNodesByRoot,
+            endpointNodesByRoot
+        );
+
+        PopulateNetResults(context, result, netNodesByRoot, representatives);
+        PopulateTerminalToNet(context, result, representatives);
+    }
+
+    private static Dictionary<string, List<string>> GroupNodesByRoot(
+        IEnumerable<string> nodes,
+        ResolutionContext context
+    )
+    {
+        var groups = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+        foreach (var node in nodes)
+        {
+            var root = context.UnionFind.Find(node);
+            if (!groups.TryGetValue(root, out var list))
+            {
+                list = new List<string>();
+                groups[root] = list;
+            }
+
+            list.Add(node);
+        }
+
+        return groups;
+    }
+
+    private Dictionary<string, string> DetermineRepresentatives(
+        ResolutionContext context,
+        Dictionary<string, List<string>> netNodesByRoot,
+        Dictionary<string, List<string>> endpointNodesByRoot
+    )
+    {
+        var representatives = new Dictionary<string, string>(StringComparer.Ordinal);
+        var roots = new HashSet<string>(netNodesByRoot.Keys, StringComparer.Ordinal);
+        roots.UnionWith(endpointNodesByRoot.Keys);
+
+        foreach (var root in roots)
+        {
+            var explicitNets = netNodesByRoot.TryGetValue(root, out var netNodes)
+                ? netNodes.Where(context.ExplicitNetNodes.Contains).ToList()
+                : new List<string>();
+
+            string representative;
+            if (explicitNets.Count > 0)
+            {
+                representative = SelectRepresentative(explicitNets, context.NetTiers);
+            }
+            else if (TryGetAnchorName(root, netNodesByRoot, context, out var anchorName))
+            {
+                representative = anchorName;
+            }
+            else
+            {
+                var endpoints = endpointNodesByRoot.GetValueOrDefault(root, new List<string>());
+                representative = ComputeAutoNetName(endpoints);
+            }
+
+            representatives[root] = representative;
+        }
+
+        return representatives;
+    }
+
+    private static bool TryGetAnchorName(
+        string root,
+        Dictionary<string, List<string>> netNodesByRoot,
+        ResolutionContext context,
+        out string anchorName
+    )
+    {
+        anchorName = string.Empty;
+        if (!netNodesByRoot.TryGetValue(root, out var netNodes))
+        {
+            return false;
+        }
+
+        var anchorNames = new SortedSet<string>(StringComparer.Ordinal);
+        foreach (var node in netNodes)
+        {
+            if (context.AutoNetNameOverrides.TryGetValue(node, out var name))
+            {
+                anchorNames.Add(name);
+            }
+        }
+
+        if (anchorNames.Count == 0)
+        {
+            return false;
+        }
+
+        anchorName = anchorNames.Min!;
+        return true;
+    }
+
+    private static string SelectRepresentative(List<string> nets, Dictionary<string, NetTier> tiers)
+    {
+        if (nets is null || nets.Count == 0)
+        {
+            throw new ArgumentException("nets must be non-empty", nameof(nets));
+        }
+
+        var grouped = nets.GroupBy(net => tiers[net]).OrderBy(group => group.Key);
+        var bestGroup = grouped.First();
+        return bestGroup.Min(StringComparer.Ordinal)!;
+    }
+
+    private static string ComputeAutoNetName(IReadOnlyList<string> endpoints)
+    {
+        if (endpoints.Count == 0)
+        {
+            return "_auto";
+        }
+
+        var ordered = endpoints.OrderBy(endpoint => endpoint, StringComparer.Ordinal).ToList();
+        var first = ordered[0];
+        var second = ordered.Count > 1 ? ordered[1] : ordered[0];
+        return $"_auto_{SanitizeEndpoint(first)}__{SanitizeEndpoint(second)}";
+    }
+
+    private static string SanitizeEndpoint(string endpoint)
+    {
+        return endpoint.Replace('.', '_');
+    }
+
+    private static string ToNetName(string terminalPath)
+    {
+        return terminalPath.Replace('.', '_');
+    }
+
+    private static void PopulateNetResults(
+        ResolutionContext context,
+        CircuitResolutionResult result,
+        Dictionary<string, List<string>> netNodesByRoot,
+        Dictionary<string, string> representatives
+    )
+    {
+        foreach (var net in context.ExplicitNetNodes)
+        {
+            var root = context.UnionFind.Find(net);
+            result._netToRepresentative[net] = representatives[root];
+        }
+
+        foreach (var (root, nets) in netNodesByRoot)
+        {
+            var representative = representatives[root];
+            var names = BuildEquivalenceNames(nets, representative, context);
+            if (names.Count > 0)
+            {
+                result._netEquivalences[representative] = names.AsReadOnly();
+            }
+        }
+    }
+
+    private static List<string> BuildEquivalenceNames(
+        List<string> netNodes,
+        string representative,
+        ResolutionContext context
+    )
+    {
+        var names = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var node in netNodes)
+        {
+            if (context.ExplicitNetNodes.Contains(node))
+            {
+                names.Add(node);
+                continue;
+            }
+
+            if (context.AutoNetNameOverrides.TryGetValue(node, out var anchorName))
+            {
+                names.Add(anchorName);
+                continue;
+            }
+
+            names.Add(representative);
+        }
+
+        return names.OrderBy(name => name, StringComparer.Ordinal).ToList();
+    }
+
+    private static void PopulateTerminalToNet(
+        ResolutionContext context,
+        CircuitResolutionResult result,
+        Dictionary<string, string> representatives
+    )
+    {
+        foreach (var endpoint in context.EndpointNodes)
+        {
+            var root = context.UnionFind.Find(endpoint);
+            result._terminalToNet[endpoint] = representatives[root];
+        }
+    }
+
+    private void PopulateAttachBindings(
+        Circuit circuit,
+        ResolutionContext context,
+        CircuitResolutionResult result
+    )
+    {
+        if (circuit.Fill?.Attaches is null || circuit.Fill.Attaches.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var attach in circuit.Fill.Attaches)
+        {
+            if (!context.ConnectorByAttach.TryGetValue(attach, out var attachInfo))
+            {
+                continue;
+            }
+
+            var connector = attachInfo.Connector;
+            var bindings = new Dictionary<string, string>(StringComparer.Ordinal);
+            var instanceChain = BuildInstanceChain(attach);
+
+            for (var pairIndex = 0; pairIndex < instanceChain.Count - 1; pairIndex++)
+            {
+                var fromInstance = instanceChain[pairIndex];
+                var toInstance = instanceChain[pairIndex + 1];
+
+                foreach (
+                    var (sourcePort, targetPort) in EnumerateConnectorMappings(attach, connector)
+                )
+                {
+                    var fromEndpoint = $"{fromInstance}.{sourcePort}";
+                    var toEndpoint = $"{toInstance}.{targetPort}";
+
+                    if (result.TerminalToNet.TryGetValue(fromEndpoint, out var netName))
+                    {
+                        var key =
+                            attach.TargetInstances.Count == 1
+                                ? sourcePort
+                                : $"{fromInstance}.{sourcePort}";
+                        bindings[key] = netName;
+                    }
+
+                    if (result.TerminalToNet.TryGetValue(toEndpoint, out var targetNet))
+                    {
+                        bindings[$"{toInstance}.{targetPort}"] = targetNet;
+                    }
+                }
+            }
+
+            if (bindings.Count > 0)
+            {
+                result._attachBindings[attach] = new ReadOnlyDictionary<string, string>(bindings);
+            }
+        }
+    }
+}

--- a/tools/acir/AttachResolver.Nodes.cs
+++ b/tools/acir/AttachResolver.Nodes.cs
@@ -1,0 +1,146 @@
+using System;
+using System.Collections.Generic;
+using Cascode.Parser;
+
+namespace Cascode.ACIR;
+
+public sealed partial class AttachResolver
+{
+    private static void AddExplicitNetNode(
+        ResolutionContext context,
+        string netName,
+        string domain,
+        NetTier tier
+    )
+    {
+        AddNode(context, netName, domain, isNet: true, isExplicit: true, tier);
+    }
+
+    private static void AddAutoNetNode(ResolutionContext context, string netName, string domain)
+    {
+        AddNode(context, netName, domain, isNet: true, isExplicit: false, tier: null);
+    }
+
+    private static void AddEndpointNode(ResolutionContext context, string endpointId, string domain)
+    {
+        AddNode(context, endpointId, domain, isNet: false, isExplicit: false, tier: null);
+    }
+
+    private static void AddNode(
+        ResolutionContext context,
+        string node,
+        string domain,
+        bool isNet,
+        bool isExplicit,
+        NetTier? tier
+    )
+    {
+        if (context.UnionFind.Contains(node))
+        {
+            return;
+        }
+
+        context.UnionFind.MakeSet(node);
+        context.NodeDomains[node] = domain;
+        context.DomainByRoot[node] = domain;
+        context.NetCountByRoot[node] = isNet ? 1 : 0;
+
+        if (isNet)
+        {
+            context.NetNodes.Add(node);
+        }
+        else
+        {
+            context.EndpointNodes.Add(node);
+        }
+
+        if (isExplicit)
+        {
+            context.ExplicitNetNodes.Add(node);
+            context.NetTiers[node] = tier ?? NetTier.Declared;
+            context.ExplicitNetNamesByRoot[node] = new SortedSet<string>(StringComparer.Ordinal)
+            {
+                node,
+            };
+        }
+    }
+
+    private static void EnsureNetNode(ResolutionContext context, string netName, string domain)
+    {
+        if (context.UnionFind.Contains(netName))
+        {
+            return;
+        }
+
+        AddExplicitNetNode(context, netName, domain, NetTier.Declared);
+    }
+
+    private static bool TryUnion(
+        ResolutionContext context,
+        string nodeA,
+        string nodeB,
+        List<Diagnostic> diagnostics,
+        string circuitName
+    )
+    {
+        var rootA = context.UnionFind.Find(nodeA);
+        var rootB = context.UnionFind.Find(nodeB);
+        if (rootA == rootB)
+        {
+            return true;
+        }
+
+        var domainA = context.DomainByRoot[rootA];
+        var domainB = context.DomainByRoot[rootB];
+        if (!string.Equals(domainA, domainB, StringComparison.Ordinal))
+        {
+            diagnostics.Add(
+                new Diagnostic(
+                    $"ACIR0024: Incompatible domain merge '{nodeA}' ({domainA}) -> '{nodeB}' ({domainB})",
+                    DiagnosticSeverity.Error,
+                    circuitName,
+                    1,
+                    1
+                )
+            );
+            return false;
+        }
+
+        context.UnionFind.Union(rootA, rootB);
+        var newRoot = context.UnionFind.Find(rootA);
+        var oldRoot = newRoot == rootA ? rootB : rootA;
+        MergeComponentInfo(context, newRoot, oldRoot);
+        return true;
+    }
+
+    private static void MergeComponentInfo(
+        ResolutionContext context,
+        string newRoot,
+        string oldRoot
+    )
+    {
+        if (context.NetCountByRoot.TryGetValue(oldRoot, out var oldCount))
+        {
+            context.NetCountByRoot[newRoot] = context.NetCountByRoot[newRoot] + oldCount;
+            context.NetCountByRoot.Remove(oldRoot);
+        }
+
+        if (context.ExplicitNetNamesByRoot.TryGetValue(oldRoot, out var oldNames))
+        {
+            if (!context.ExplicitNetNamesByRoot.TryGetValue(newRoot, out var newNames))
+            {
+                newNames = new SortedSet<string>(StringComparer.Ordinal);
+                context.ExplicitNetNamesByRoot[newRoot] = newNames;
+            }
+
+            foreach (var name in oldNames)
+            {
+                newNames.Add(name);
+            }
+
+            context.ExplicitNetNamesByRoot.Remove(oldRoot);
+        }
+
+        context.DomainByRoot.Remove(oldRoot);
+    }
+}

--- a/tools/acir/AttachResolver.Setup.cs
+++ b/tools/acir/AttachResolver.Setup.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cascode.Parser;
+
+namespace Cascode.ACIR;
+
+public sealed partial class AttachResolver
+{
+    private void InitializeNetAtoms(Circuit circuit, ResolutionContext context)
+    {
+        foreach (var net in circuit.Fill!.Nets)
+        {
+            AddExplicitNetNode(context, net.Id, net.Domain, NetTier.Declared);
+        }
+
+        foreach (var supply in circuit.Supplies)
+        {
+            AddExplicitNetNode(context, supply, PowerDomain, NetTier.Supply);
+        }
+
+        foreach (var ground in circuit.Grounds)
+        {
+            AddExplicitNetNode(context, ground, GroundDomain, NetTier.Ground);
+        }
+
+        foreach (var port in circuit.Ports)
+        {
+            foreach (var (terminalPath, domain) in ExpandPortTerminalPaths(port))
+            {
+                var netName = ToNetName(terminalPath);
+                AddExplicitNetNode(context, netName, domain, NetTier.PortExpansion);
+            }
+        }
+    }
+
+    private void InitializeInstanceEndpoints(Circuit circuit, ResolutionContext context)
+    {
+        foreach (var instance in circuit.Fill!.Instances)
+        {
+            if (!_circuitsByName.TryGetValue(instance.Type, out var targetCircuit))
+            {
+                continue;
+            }
+
+            foreach (var (terminalPath, domain) in EnumerateCircuitTerminals(targetCircuit))
+            {
+                var endpointId = $"{instance.Id}.{terminalPath}";
+                AddEndpointNode(context, endpointId, domain);
+            }
+        }
+    }
+
+    private IEnumerable<(string TerminalPath, string Domain)> EnumerateCircuitTerminals(
+        Circuit circuit
+    )
+    {
+        foreach (var supply in circuit.Supplies)
+        {
+            yield return (supply, PowerDomain);
+        }
+
+        foreach (var ground in circuit.Grounds)
+        {
+            yield return (ground, GroundDomain);
+        }
+
+        foreach (var port in circuit.Ports)
+        {
+            foreach (var entry in ExpandPortTerminalPaths(port))
+            {
+                yield return entry;
+            }
+        }
+    }
+
+    private void ApplyDeviceBindings(Circuit circuit, ResolutionContext context)
+    {
+        foreach (var device in circuit.Fill!.Devices)
+        {
+            foreach (var netName in device.Bindings.Values)
+            {
+                EnsureNetNode(context, netName, DefaultDomain);
+            }
+        }
+    }
+
+    private void ApplyInstanceBindings(
+        Circuit circuit,
+        ResolutionContext context,
+        List<Diagnostic> diagnostics
+    )
+    {
+        foreach (var instance in circuit.Fill!.Instances)
+        {
+            foreach (var binding in instance.Bindings)
+            {
+                var endpointId = $"{instance.Id}.{binding.Key}";
+                EnsureEndpointNode(instance, binding.Key, endpointId, context);
+                EnsureNetNode(context, binding.Value, DefaultDomain);
+                TryUnion(context, endpointId, binding.Value, diagnostics, circuit.Name);
+            }
+        }
+    }
+
+    private void ApplyConnectStatements(
+        Circuit circuit,
+        ResolutionContext context,
+        List<Diagnostic> diagnostics
+    )
+    {
+        if (circuit.Fill!.Connections.Count == 0)
+        {
+            return;
+        }
+
+        var instancesById = circuit.Fill.Instances.ToDictionary(
+            inst => inst.Id,
+            StringComparer.Ordinal
+        );
+
+        foreach (var conn in circuit.Fill.Connections)
+        {
+            var fromNode = ResolveEndpointNode(circuit, instancesById, conn.From, context);
+            var toNode = ResolveEndpointNode(circuit, instancesById, conn.To, context);
+            TryUnion(context, fromNode, toNode, diagnostics, circuit.Name);
+        }
+    }
+
+    private string ResolveEndpointNode(
+        Circuit parentCircuit,
+        Dictionary<string, InstanceDeclaration> instancesById,
+        string endpoint,
+        ResolutionContext context
+    )
+    {
+        var dotIndex = endpoint.IndexOf('.', StringComparison.Ordinal);
+        if (dotIndex > 0)
+        {
+            var instanceId = endpoint[..dotIndex];
+            if (instancesById.TryGetValue(instanceId, out var instance))
+            {
+                var terminalPath = endpoint[(dotIndex + 1)..];
+                var endpointId = endpoint;
+                EnsureEndpointNode(instance, terminalPath, endpointId, context);
+                return endpointId;
+            }
+        }
+
+        EnsureNetNode(context, endpoint, DefaultDomain);
+        return endpoint;
+    }
+}

--- a/tools/acir/AttachResolver.Terminals.cs
+++ b/tools/acir/AttachResolver.Terminals.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Cascode.ACIR;
+
+public sealed partial class AttachResolver
+{
+    private void EnsureEndpointNode(
+        InstanceDeclaration instance,
+        string terminalPath,
+        string endpointId,
+        ResolutionContext context
+    )
+    {
+        if (context.UnionFind.Contains(endpointId))
+        {
+            return;
+        }
+
+        var domain = ResolveInstanceTerminalDomain(instance, terminalPath) ?? DefaultDomain;
+        AddEndpointNode(context, endpointId, domain);
+    }
+
+    private string? ResolveInstanceTerminalDomain(InstanceDeclaration instance, string terminalPath)
+    {
+        if (!_circuitsByName.TryGetValue(instance.Type, out var targetCircuit))
+        {
+            return null;
+        }
+
+        return TryResolveTerminalDomain(targetCircuit, terminalPath);
+    }
+
+    private string? TryResolveTerminalDomain(Circuit circuit, string terminalPath)
+    {
+        var parts = terminalPath.Split('.', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0)
+        {
+            return null;
+        }
+
+        var baseName = parts[0];
+        if (circuit.Supplies.Contains(baseName))
+        {
+            return parts.Length == 1 ? PowerDomain : null;
+        }
+
+        if (circuit.Grounds.Contains(baseName))
+        {
+            return parts.Length == 1 ? GroundDomain : null;
+        }
+
+        var port = circuit.Ports.FirstOrDefault(p =>
+            p.Name.Equals(baseName, StringComparison.Ordinal)
+        );
+        if (port is null)
+        {
+            return null;
+        }
+
+        if (parts.Length == 1)
+        {
+            return port.Type;
+        }
+
+        return ResolveBundleFieldDomain(port.Type, parts, 1);
+    }
+
+    private string? ResolveBundleFieldDomain(string typeName, string[] pathSegments, int index)
+    {
+        if (index >= pathSegments.Length)
+        {
+            return typeName;
+        }
+
+        if (!_bundleTypesByName.TryGetValue(typeName, out var bundle))
+        {
+            return null;
+        }
+
+        var fieldName = pathSegments[index];
+        if (!bundle.Fields.TryGetValue(fieldName, out var fieldType))
+        {
+            return null;
+        }
+
+        return ResolveBundleFieldDomain(fieldType, pathSegments, index + 1);
+    }
+
+    private IEnumerable<(string TerminalPath, string Domain)> ExpandPortTerminalPaths(
+        PortDeclaration port
+    )
+    {
+        return ExpandBundleTerminalPaths(port.Name, port.Type);
+    }
+
+    private IEnumerable<(string TerminalPath, string Domain)> ExpandBundleTerminalPaths(
+        string basePath,
+        string typeName
+    )
+    {
+        if (!_bundleTypesByName.TryGetValue(typeName, out var bundle))
+        {
+            yield return (basePath, typeName);
+            yield break;
+        }
+
+        foreach (var field in bundle.Fields.OrderBy(f => f.Key, StringComparer.Ordinal))
+        {
+            var path = $"{basePath}.{field.Key}";
+            foreach (var entry in ExpandBundleTerminalPaths(path, field.Value))
+            {
+                yield return entry;
+            }
+        }
+    }
+}

--- a/tools/acir/AttachResolver.cs
+++ b/tools/acir/AttachResolver.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Cascode.Parser;
+
+namespace Cascode.ACIR;
+
+/// <summary>
+/// Resolves attach statements to determine net connectivity using union-find.
+/// </summary>
+public sealed partial class AttachResolver
+{
+    private const string PowerDomain = "power";
+    private const string GroundDomain = "ground";
+    private const string DefaultDomain = "analog";
+
+    private readonly ACIRDocument _document;
+    private readonly Dictionary<string, TraitDefinition> _traitsByName;
+    private readonly Dictionary<string, Circuit> _circuitsByName;
+    private readonly Dictionary<string, BundleType> _bundleTypesByName;
+    private readonly List<Diagnostic> _constructorDiagnostics = new();
+
+    /// <summary>
+    /// Initializes a new AttachResolver for the given document.
+    /// </summary>
+    public AttachResolver(ACIRDocument document)
+    {
+        _document = document;
+        _traitsByName = BuildLookup(document.Traits, t => t.Name, "trait", _constructorDiagnostics);
+        _circuitsByName = BuildLookup(
+            document.Circuits,
+            c => c.Name,
+            "circuit",
+            _constructorDiagnostics
+        );
+        _bundleTypesByName = BuildLookup(
+            document.BundleTypes,
+            b => b.Name,
+            "bundle type",
+            _constructorDiagnostics
+        );
+    }
+
+    /// <summary>
+    /// Resolves all attach statements in the document, returning the resolved
+    /// net connectivity map and any diagnostics.
+    /// </summary>
+    public AttachResolutionResult Resolve()
+    {
+        var result = new AttachResolutionResult();
+        result._diagnostics.AddRange(_constructorDiagnostics);
+
+        foreach (var circuit in _document.Circuits)
+        {
+            if (circuit.Fill is null)
+            {
+                continue;
+            }
+
+            var circuitResult = ResolveCircuit(circuit);
+            result._circuitResults[circuit.Name] = circuitResult;
+            result._diagnostics.AddRange(circuitResult.Diagnostics);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Resolves attach statements for a single circuit.
+    /// </summary>
+    private CircuitResolutionResult ResolveCircuit(Circuit circuit)
+    {
+        var result = new CircuitResolutionResult();
+        // Defensive: Resolve() pre-filters null Fill, but guard here for direct calls.
+        if (circuit.Fill is null)
+        {
+            return result;
+        }
+
+        var context = new ResolutionContext();
+        InitializeNetAtoms(circuit, context);
+        InitializeInstanceEndpoints(circuit, context);
+        ApplyDeviceBindings(circuit, context);
+        ApplyInstanceBindings(circuit, context, result._diagnostics);
+        ApplyConnectStatements(circuit, context, result._diagnostics);
+        ApplyAttachStatements(circuit, context, result._diagnostics);
+        FinalizeResolution(context, result);
+        PopulateAttachBindings(circuit, context, result);
+
+        return result;
+    }
+
+    internal static List<string> BuildInstanceChain(AttachStatement attach)
+    {
+        var chain = new List<string>(1 + attach.TargetInstances.Count) { attach.SourceInstance };
+        chain.AddRange(attach.TargetInstances);
+        return chain;
+    }
+
+    private static Dictionary<string, T> BuildLookup<T>(
+        IEnumerable<T> items,
+        Func<T, string> nameSelector,
+        string itemKind,
+        List<Diagnostic> diagnostics
+    )
+    {
+        var lookup = new Dictionary<string, T>(StringComparer.Ordinal);
+        foreach (var item in items)
+        {
+            var name = nameSelector(item);
+            if (!lookup.TryAdd(name, item))
+            {
+                diagnostics.Add(
+                    new Diagnostic(
+                        $"ACIR0026: Duplicate {itemKind} name '{name}'; keeping first definition",
+                        DiagnosticSeverity.Warning,
+                        "<document>",
+                        1,
+                        1
+                    )
+                );
+            }
+        }
+
+        return lookup;
+    }
+}

--- a/tools/acir/Json/AcirJsonConverter.cs
+++ b/tools/acir/Json/AcirJsonConverter.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using Cascode.Parser;
 
 namespace Cascode.ACIR.Json;
 
@@ -53,33 +54,118 @@ public static class AcirJsonConverter
     }
 
     /// <summary>
-    /// Parses JSON string into an ACIRDocument.
+    /// Parses JSON string into an ACIRDocument with structured error handling.
     /// </summary>
     /// <param name="json">The JSON string to parse.</param>
-    /// <returns>The ACIR document.</returns>
-    /// <exception cref="ArgumentException">If parsing fails.</exception>
-    public static ACIRDocument FromJson(string json)
+    /// <param name="filePath">Optional file path for diagnostic messages.</param>
+    /// <returns>Read result containing the document and any diagnostics.</returns>
+    public static ACIRReadResult FromJson(string json, string filePath = "<json>")
     {
-        var jsonDoc =
-            JsonSerializer.Deserialize<AcirJsonDocument>(json, JsonOptions)
-            ?? throw new ArgumentException("Failed to parse JSON document.");
-        return FromJsonDocument(jsonDoc);
+        var diagnostics = new List<Diagnostic>();
+
+        AcirJsonDocument? jsonDoc;
+        try
+        {
+            jsonDoc = JsonSerializer.Deserialize<AcirJsonDocument>(json, JsonOptions);
+        }
+        catch (JsonException ex)
+        {
+            diagnostics.Add(
+                new Diagnostic(
+                    $"ACIR0009: JSON parse error: {ex.Message}",
+                    DiagnosticSeverity.Error,
+                    filePath,
+                    1,
+                    1
+                )
+            );
+            return new ACIRReadResult { Document = null, Diagnostics = diagnostics };
+        }
+
+        if (jsonDoc == null)
+        {
+            diagnostics.Add(
+                new Diagnostic(
+                    "ACIR0009: Failed to parse JSON document (null result)",
+                    DiagnosticSeverity.Error,
+                    filePath,
+                    1,
+                    1
+                )
+            );
+            return new ACIRReadResult { Document = null, Diagnostics = diagnostics };
+        }
+
+        return FromJsonDocument(jsonDoc, filePath, diagnostics);
     }
 
     /// <summary>
-    /// Converts AcirJsonDocument back to ACIRDocument.
+    /// Converts AcirJsonDocument back to ACIRDocument with structured error handling.
     /// </summary>
     /// <param name="jsonDoc">The JSON document to convert.</param>
-    /// <returns>The ACIR document.</returns>
-    public static ACIRDocument FromJsonDocument(AcirJsonDocument jsonDoc)
+    /// <param name="filePath">Optional file path for diagnostic messages.</param>
+    /// <param name="diagnostics">Optional diagnostics list to append to.</param>
+    /// <returns>Read result containing the document and any diagnostics.</returns>
+    public static ACIRReadResult FromJsonDocument(
+        AcirJsonDocument jsonDoc,
+        string filePath = "<json>",
+        List<Diagnostic>? diagnostics = null
+    )
     {
-        var version = ParseVersion(jsonDoc.AcirVersion);
+        diagnostics ??= new List<Diagnostic>();
+
+        // Parse version with error handling
+        int major,
+            minor;
+        try
+        {
+            (major, minor) = ParseVersion(jsonDoc.AcirVersion);
+        }
+        catch (FormatException ex)
+        {
+            diagnostics.Add(
+                new Diagnostic($"ACIR0002: {ex.Message}", DiagnosticSeverity.Error, filePath, 1, 1)
+            );
+            return new ACIRReadResult { Document = null, Diagnostics = diagnostics };
+        }
+
+        // Validate major version
+        if (major != ACIRVersion.Major)
+        {
+            diagnostics.Add(
+                new Diagnostic(
+                    $"ACIR0007: ACIR major version {major} not supported. Expected major version {ACIRVersion.Major}.",
+                    DiagnosticSeverity.Error,
+                    filePath,
+                    1,
+                    1
+                )
+            );
+            return new ACIRReadResult { Document = null, Diagnostics = diagnostics };
+        }
+
+        // Parse level with error handling - NO FALLBACK
+        if (!Enum.TryParse<ACIRLevel>(jsonDoc.Circuit.Level, ignoreCase: true, out var level))
+        {
+            diagnostics.Add(
+                new Diagnostic(
+                    $"ACIR0008: Invalid level '{jsonDoc.Circuit.Level}' - expected HL, ML, or EL",
+                    DiagnosticSeverity.Error,
+                    filePath,
+                    1,
+                    1
+                )
+            );
+            return new ACIRReadResult { Document = null, Diagnostics = diagnostics };
+        }
 
         var circuit = new Circuit
         {
             Name = jsonDoc.Circuit.Name,
             Traits = jsonDoc.Circuit.Traits?.ToList(),
-            Level = ACIRLevel.EL,
+            Level = level,
+            Inline = jsonDoc.Circuit.Inline,
+            Parameters = BuildCircuitParameters(jsonDoc.Circuit.Parameters),
             Supplies = jsonDoc.Supplies.ToList(),
             Grounds = jsonDoc.Grounds.ToList(),
             Ports = jsonDoc
@@ -99,12 +185,15 @@ public static class AcirJsonConverter
                     : null,
         };
 
-        return new ACIRDocument
+        var doc = new ACIRDocument
         {
-            VersionMajor = version.major,
-            VersionMinor = version.minor,
+            VersionMajor = major,
+            VersionMinor = minor,
+            Traits = BuildTraits(jsonDoc.Traits),
             Circuits = [circuit],
         };
+
+        return new ACIRReadResult { Document = doc, Diagnostics = diagnostics };
     }
 
     private static Circuit? FindElCircuit(ACIRDocument document, string? circuitName)
@@ -124,11 +213,14 @@ public static class AcirJsonConverter
         return new AcirJsonDocument
         {
             AcirVersion = $"{document.VersionMajor}.{document.VersionMinor}",
+            Traits = ConvertTraits(document.Traits),
             Circuit = new AcirJsonCircuitInfo
             {
                 Name = circuit.Name,
                 Traits = circuit.Traits?.Count > 0 ? circuit.Traits : null,
-                Level = "EL",
+                Level = circuit.Level.ToString(),
+                Inline = circuit.Inline,
+                Parameters = ConvertCircuitParameters(circuit.Parameters),
             },
             Supplies = circuit.Supplies,
             Grounds = circuit.Grounds,
@@ -137,6 +229,8 @@ public static class AcirJsonConverter
                 .ToList(),
             Nets = ConvertNets(circuit.Fill),
             Components = ConvertDevices(circuit.Fill),
+            Instances = ConvertInstances(circuit.Fill),
+            Attaches = ConvertAttaches(circuit.Fill),
             Constraints = ConvertConstraints(circuit.Constraints),
             Harness = ConvertHarness(circuit.Harness),
             Benches = circuit.Benches?.Benches.Select(b => b.Name).ToList() ?? [],
@@ -164,6 +258,116 @@ public static class AcirJsonConverter
                 Connections = d.Bindings,
                 Params = d.Params,
                 Process = d.PdkDevice,
+            })
+            .ToList();
+    }
+
+    private static List<AcirJsonTrait>? ConvertTraits(List<TraitDefinition> traits)
+    {
+        if (traits.Count == 0)
+            return null;
+
+        return traits
+            .Select(t => new AcirJsonTrait
+            {
+                Name = t.Name,
+                Ports = t
+                    .Ports.Select(p => new AcirJsonPort { Name = p.Name, Kind = p.Type })
+                    .ToList(),
+                Connectors =
+                    t.Connectors.Count > 0
+                        ? t
+                            .Connectors.Select(c => new AcirJsonConnector
+                            {
+                                TargetTrait = c.TargetTrait,
+                                Mappings = c
+                                    .Mappings.Select(m => new AcirJsonMapping
+                                    {
+                                        Source = m.SourcePort,
+                                        Target = m.TargetPort,
+                                    })
+                                    .ToList(),
+                            })
+                            .ToList()
+                        : null,
+            })
+            .ToList();
+    }
+
+    private static List<AcirJsonCircuitParameter>? ConvertCircuitParameters(
+        List<CircuitParameter> parameters
+    )
+    {
+        if (parameters.Count == 0)
+            return null;
+
+        return parameters
+            .Select(p => new AcirJsonCircuitParameter
+            {
+                Name = p.Name,
+                Type = p.Type,
+                Default = p.Default switch
+                {
+                    { Symbolic: not null } => p.Default.Symbolic,
+                    { Numeric: not null } => p.Default.Numeric,
+                    { Literal: not null } => p.Default.Literal,
+                    _ => null,
+                },
+            })
+            .ToList();
+    }
+
+    private static List<AcirJsonInstance>? ConvertInstances(FillBlock? fill)
+    {
+        if (fill?.Instances.Count is null or 0)
+            return null;
+
+        return fill
+            .Instances.Select(i => new AcirJsonInstance
+            {
+                Id = i.Id,
+                Type = i.Type,
+                Bindings = i.Bindings,
+                Params =
+                    i.Params.Count > 0
+                        ? i.Params.ToDictionary(
+                            p => p.Key,
+                            p =>
+                                p.Value switch
+                                {
+                                    { Symbolic: not null } => p.Value.Symbolic,
+                                    { Numeric: not null } => p.Value.Numeric,
+                                    { Literal: not null } => p.Value.Literal!,
+                                    _ => "",
+                                }
+                        )
+                        : null,
+            })
+            .ToList();
+    }
+
+    private static List<AcirJsonAttach>? ConvertAttaches(FillBlock? fill)
+    {
+        if (fill?.Attaches.Count is null or 0)
+            return null;
+
+        return fill
+            .Attaches.Select(a => new AcirJsonAttach
+            {
+                SourceInstance = a.SourceInstance,
+                TargetInstances = a.TargetInstances,
+                Via = a.Via,
+                Anchor = a.Anchor,
+                Overrides =
+                    a.Overrides?.Count > 0
+                        ? a
+                            .Overrides.Select(o => new AcirJsonMapping
+                            {
+                                Source = o.SourcePort,
+                                Target = o.TargetPort,
+                            })
+                            .ToList()
+                        : null,
             })
             .ToList();
     }
@@ -356,7 +560,85 @@ public static class AcirJsonConverter
                     PdkDevice = c.Process,
                 })
                 .ToList(),
+            Instances =
+                jsonDoc
+                    .Instances?.Select(i => new InstanceDeclaration
+                    {
+                        Id = i.Id,
+                        Type = i.Type,
+                        Bindings = new Dictionary<string, string>(i.Bindings),
+                        Params =
+                            i.Params?.ToDictionary(p => p.Key, p => ParamValueParser.Parse(p.Value))
+                            ?? new Dictionary<string, ParamValue>(),
+                    })
+                    .ToList()
+                ?? [],
+            Attaches =
+                jsonDoc
+                    .Attaches?.Select(a => new AttachStatement
+                    {
+                        SourceInstance = a.SourceInstance,
+                        TargetInstances = a.TargetInstances.ToList(),
+                        Via = a.Via,
+                        Anchor = a.Anchor,
+                        Overrides = a
+                            .Overrides?.Select(o => new ConnectorMapping
+                            {
+                                SourcePort = o.Source,
+                                TargetPort = o.Target,
+                            })
+                            .ToList(),
+                    })
+                    .ToList()
+                ?? [],
         };
+    }
+
+    private static List<TraitDefinition> BuildTraits(IReadOnlyList<AcirJsonTrait>? traits)
+    {
+        if (traits is null or { Count: 0 })
+            return [];
+
+        return traits
+            .Select(t => new TraitDefinition
+            {
+                Name = t.Name,
+                Ports = t
+                    .Ports.Select(p => new PortDeclaration { Name = p.Name, Type = p.Kind })
+                    .ToList(),
+                Connectors =
+                    t.Connectors?.Select(c => new TraitConnector
+                        {
+                            TargetTrait = c.TargetTrait,
+                            Mappings = c
+                                .Mappings.Select(m => new ConnectorMapping
+                                {
+                                    SourcePort = m.Source,
+                                    TargetPort = m.Target,
+                                })
+                                .ToList(),
+                        })
+                        .ToList()
+                    ?? [],
+            })
+            .ToList();
+    }
+
+    private static List<CircuitParameter> BuildCircuitParameters(
+        IReadOnlyList<AcirJsonCircuitParameter>? parameters
+    )
+    {
+        if (parameters is null or { Count: 0 })
+            return [];
+
+        return parameters
+            .Select(p => new CircuitParameter
+            {
+                Name = p.Name,
+                Type = p.Type,
+                Default = p.Default is not null ? ParamValueParser.Parse(p.Default) : null,
+            })
+            .ToList();
     }
 
     private static ConstraintsBlock? BuildConstraintsBlock(AcirJsonConstraints? constraints)

--- a/tools/acir/Json/AcirJsonDocument.cs
+++ b/tools/acir/Json/AcirJsonDocument.cs
@@ -11,6 +11,10 @@ public sealed record AcirJsonDocument
     [JsonPropertyName("acirVersion")]
     public string AcirVersion { get; init; } = ACIRVersion.Current;
 
+    [JsonPropertyName("traits")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<AcirJsonTrait>? Traits { get; init; }
+
     [JsonPropertyName("circuit")]
     public required AcirJsonCircuitInfo Circuit { get; init; }
 
@@ -28,6 +32,14 @@ public sealed record AcirJsonDocument
 
     [JsonPropertyName("components")]
     public IReadOnlyList<AcirJsonComponent> Components { get; init; } = [];
+
+    [JsonPropertyName("instances")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<AcirJsonInstance>? Instances { get; init; }
+
+    [JsonPropertyName("attaches")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<AcirJsonAttach>? Attaches { get; init; }
 
     [JsonPropertyName("constraints")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -55,6 +67,14 @@ public sealed record AcirJsonCircuitInfo
 
     [JsonPropertyName("level")]
     public string Level { get; init; } = "EL";
+
+    [JsonPropertyName("inline")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    public bool Inline { get; init; }
+
+    [JsonPropertyName("parameters")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<AcirJsonCircuitParameter>? Parameters { get; init; }
 }
 
 /// <summary>
@@ -267,4 +287,103 @@ public sealed record AcirJsonHarnessSweep
     [JsonPropertyName("isAuto")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     public bool IsAuto { get; init; }
+}
+
+/// <summary>
+/// Trait definition in JSON format.
+/// </summary>
+public sealed record AcirJsonTrait
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("ports")]
+    public IReadOnlyList<AcirJsonPort> Ports { get; init; } = [];
+
+    [JsonPropertyName("connectors")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<AcirJsonConnector>? Connectors { get; init; }
+}
+
+/// <summary>
+/// Trait connector definition in JSON format.
+/// </summary>
+public sealed record AcirJsonConnector
+{
+    [JsonPropertyName("targetTrait")]
+    public required string TargetTrait { get; init; }
+
+    [JsonPropertyName("mappings")]
+    public IReadOnlyList<AcirJsonMapping> Mappings { get; init; } = [];
+}
+
+/// <summary>
+/// Port mapping in a connector.
+/// </summary>
+public sealed record AcirJsonMapping
+{
+    [JsonPropertyName("source")]
+    public required string Source { get; init; }
+
+    [JsonPropertyName("target")]
+    public required string Target { get; init; }
+}
+
+/// <summary>
+/// Circuit parameter declaration in JSON format.
+/// </summary>
+public sealed record AcirJsonCircuitParameter
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    [JsonPropertyName("type")]
+    public required string Type { get; init; }
+
+    [JsonPropertyName("default")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Default { get; init; }
+}
+
+/// <summary>
+/// Instance declaration in JSON format (ML level).
+/// </summary>
+public sealed record AcirJsonInstance
+{
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    [JsonPropertyName("type")]
+    public required string Type { get; init; }
+
+    [JsonPropertyName("bindings")]
+    public IReadOnlyDictionary<string, string> Bindings { get; init; } =
+        new Dictionary<string, string>();
+
+    [JsonPropertyName("params")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Params { get; init; }
+}
+
+/// <summary>
+/// Attach statement in JSON format.
+/// </summary>
+public sealed record AcirJsonAttach
+{
+    [JsonPropertyName("sourceInstance")]
+    public required string SourceInstance { get; init; }
+
+    [JsonPropertyName("targetInstances")]
+    public required IReadOnlyList<string> TargetInstances { get; init; }
+
+    [JsonPropertyName("via")]
+    public required string Via { get; init; }
+
+    [JsonPropertyName("anchor")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Anchor { get; init; }
+
+    [JsonPropertyName("overrides")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<AcirJsonMapping>? Overrides { get; init; }
 }

--- a/tools/acir/ParamValueParser.cs
+++ b/tools/acir/ParamValueParser.cs
@@ -1,0 +1,34 @@
+using System.Text.RegularExpressions;
+
+namespace Cascode.ACIR;
+
+/// <summary>
+/// Parses string values into ParamValue instances with correct type classification.
+/// </summary>
+public static partial class ParamValueParser
+{
+    /// <summary>
+    /// Parses a parameter value string into a ParamValue with the appropriate field set.
+    /// </summary>
+    /// <param name="value">The value string to parse.</param>
+    /// <returns>A ParamValue with the appropriate field set (Symbolic, Numeric, or Literal).</returns>
+    public static ParamValue Parse(string value)
+    {
+        if (value.StartsWith('$'))
+            return new ParamValue { Symbolic = value };
+
+        if (NumericValuePattern().IsMatch(value))
+            return new ParamValue { Numeric = value };
+
+        return new ParamValue { Literal = value };
+    }
+
+    /// <summary>
+    /// Regex pattern for numeric values with optional SI suffixes.
+    /// Matches: optional leading minus, digits, optional decimal, optional SI suffix, optional unit letters.
+    /// Examples: "10k", "-1.5M", "180n", "2u", "1.8" - all numeric.
+    /// Non-matches: "res1stor", "nmos2" - these are literals.
+    /// </summary>
+    [GeneratedRegex(@"^-?\d+\.?\d*[fpnumkMGT]?[A-Za-z]*$")]
+    private static partial Regex NumericValuePattern();
+}

--- a/tools/acir/ParameterEvaluator.cs
+++ b/tools/acir/ParameterEvaluator.cs
@@ -1,0 +1,288 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace Cascode.ACIR;
+
+/// <summary>
+/// Evaluates parameter expressions in ACIR, supporting symbolic references
+/// and arithmetic operations with SI unit prefixes.
+/// </summary>
+/// <remarks>
+/// Expression grammar (per spec):
+/// <code>
+/// paramExpr = paramValue ((* | / | + | -) paramValue)*
+/// paramValue = NUMBER SIUNIT? | $ IDENT
+/// </code>
+/// Evaluation is left-to-right with no operator precedence.
+/// </remarks>
+public static class ParameterEvaluator
+{
+    private static readonly Regex TokenPattern = new(
+        @"(\$[A-Za-z_][A-Za-z0-9_]*)|([+\-*/])|([0-9]*\.?[0-9]+(?:[eE][+\-]?[0-9]+)?[fpnumkMGT]?)",
+        RegexOptions.Compiled
+    );
+
+    private static readonly Dictionary<char, double> SIPrefixes = new()
+    {
+        ['f'] = 1e-15,
+        ['p'] = 1e-12,
+        ['n'] = 1e-9,
+        ['u'] = 1e-6,
+        ['m'] = 1e-3,
+        ['k'] = 1e3,
+        ['M'] = 1e6,
+        ['G'] = 1e9,
+        ['T'] = 1e12,
+    };
+
+    /// <summary>
+    /// Evaluates a parameter expression given bound parameter values.
+    /// </summary>
+    /// <param name="expression">Expression to evaluate (e.g., "$W_input*2", "1u").</param>
+    /// <param name="bindings">Map of parameter names to their values.</param>
+    /// <returns>Evaluated numeric value as a string with appropriate SI prefix.</returns>
+    /// <exception cref="ArgumentException">Thrown if expression is invalid or references undefined parameters.</exception>
+    public static string Evaluate(string expression, IReadOnlyDictionary<string, string> bindings)
+    {
+        ArgumentNullException.ThrowIfNull(expression);
+        bindings ??= new Dictionary<string, string>();
+
+        var tokens = Tokenize(expression);
+        if (tokens.Count == 0)
+        {
+            throw new ArgumentException($"Empty or invalid expression: '{expression}'");
+        }
+
+        // Single value - no operators
+        if (tokens.Count == 1)
+        {
+            return EvaluateSingleValue(tokens[0], bindings);
+        }
+
+        // Evaluate left-to-right
+        var result = ResolveValue(tokens[0], bindings);
+        int i = 1;
+        while (i < tokens.Count)
+        {
+            if (i + 1 >= tokens.Count)
+            {
+                throw new ArgumentException(
+                    $"Incomplete expression: operator without operand in '{expression}'"
+                );
+            }
+
+            var op = tokens[i];
+            var right = ResolveValue(tokens[i + 1], bindings);
+
+            result = op switch
+            {
+                "+" => result + right,
+                "-" => result - right,
+                "*" => result * right,
+                "/" => right != 0 ? result / right : throw new DivideByZeroException(),
+                _ => throw new ArgumentException($"Unknown operator: {op}"),
+            };
+
+            i += 2;
+        }
+
+        return FormatNumeric(result);
+    }
+
+    /// <summary>
+    /// Parses an SI-prefixed numeric value to double.
+    /// </summary>
+    /// <param name="value">Numeric string with optional SI prefix (e.g., "2u", "100n", "1.5k").</param>
+    /// <returns>Parsed double value.</returns>
+    /// <exception cref="ArgumentException">Thrown if value cannot be parsed.</exception>
+    public static double ParseNumeric(string value)
+    {
+        ArgumentNullException.ThrowIfNull(value);
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException("Empty numeric value");
+        }
+
+        value = value.Trim();
+
+        // Check for SI prefix at end
+        var lastChar = value[^1];
+        if (SIPrefixes.TryGetValue(lastChar, out var multiplier))
+        {
+            var numPart = value[..^1];
+            if (
+                double.TryParse(
+                    numPart,
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out var num
+                )
+            )
+            {
+                return num * multiplier;
+            }
+            throw new ArgumentException($"Cannot parse numeric portion: '{numPart}'");
+        }
+
+        // No SI prefix - parse as-is
+        if (
+            double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var result)
+        )
+        {
+            return result;
+        }
+
+        throw new ArgumentException($"Cannot parse numeric value: '{value}'");
+    }
+
+    /// <summary>
+    /// Formats a double value back to a string with appropriate SI prefix.
+    /// </summary>
+    /// <param name="value">Numeric value to format.</param>
+    /// <returns>Formatted string with SI prefix for readability.</returns>
+    public static string FormatNumeric(double value)
+    {
+        if (value == 0)
+        {
+            return "0";
+        }
+
+        var absValue = Math.Abs(value);
+
+        // Select appropriate SI prefix
+        if (absValue >= 1e12)
+        {
+            return FormatWithPrefix(value, 1e12, "T");
+        }
+        if (absValue >= 1e9)
+        {
+            return FormatWithPrefix(value, 1e9, "G");
+        }
+        if (absValue >= 1e6)
+        {
+            return FormatWithPrefix(value, 1e6, "M");
+        }
+        if (absValue >= 1e3)
+        {
+            return FormatWithPrefix(value, 1e3, "k");
+        }
+        if (absValue >= 1)
+        {
+            return value.ToString("G6", CultureInfo.InvariantCulture);
+        }
+        if (absValue >= 1e-3)
+        {
+            return FormatWithPrefix(value, 1e-3, "m");
+        }
+        if (absValue >= 1e-6)
+        {
+            return FormatWithPrefix(value, 1e-6, "u");
+        }
+        if (absValue >= 1e-9)
+        {
+            return FormatWithPrefix(value, 1e-9, "n");
+        }
+        if (absValue >= 1e-12)
+        {
+            return FormatWithPrefix(value, 1e-12, "p");
+        }
+        if (absValue >= 1e-15)
+        {
+            return FormatWithPrefix(value, 1e-15, "f");
+        }
+
+        // Very small or unusual values - use scientific notation
+        return value.ToString("G6", CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Formats a value with the specified SI prefix.
+    /// </summary>
+    private static string FormatWithPrefix(double value, double divisor, string prefix)
+    {
+        var scaled = value / divisor;
+        var formatted = scaled.ToString("G6", CultureInfo.InvariantCulture);
+        return formatted + prefix;
+    }
+
+    /// <summary>
+    /// Tokenizes an expression into values and operators.
+    /// </summary>
+    private static List<string> Tokenize(string expression)
+    {
+        var tokens = new List<string>();
+        var matches = TokenPattern.Matches(expression);
+
+        foreach (Match match in matches)
+        {
+            tokens.Add(match.Value);
+        }
+
+        return tokens;
+    }
+
+    /// <summary>
+    /// Evaluates a single value (no operators).
+    /// </summary>
+    private static string EvaluateSingleValue(
+        string token,
+        IReadOnlyDictionary<string, string> bindings
+    )
+    {
+        if (token.StartsWith('$'))
+        {
+            var paramName = token[1..];
+            return ResolveParameter(paramName, bindings);
+        }
+        return token;
+    }
+
+    /// <summary>
+    /// Resolves a token to its numeric value.
+    /// </summary>
+    private static double ResolveValue(string token, IReadOnlyDictionary<string, string> bindings)
+    {
+        if (token.StartsWith('$'))
+        {
+            var paramName = token[1..];
+            var resolved = ResolveParameter(paramName, bindings);
+            return ParseNumeric(resolved);
+        }
+        return ParseNumeric(token);
+    }
+
+    /// <summary>
+    /// Resolves a parameter reference, supporting recursive resolution for chained references.
+    /// </summary>
+    private static string ResolveParameter(
+        string paramName,
+        IReadOnlyDictionary<string, string> bindings,
+        HashSet<string>? visited = null
+    )
+    {
+        visited ??= new HashSet<string>(StringComparer.Ordinal);
+
+        if (!bindings.TryGetValue(paramName, out var value))
+        {
+            throw new ArgumentException($"Undefined parameter reference: ${paramName}");
+        }
+
+        // Check for circular reference
+        if (!visited.Add(paramName))
+        {
+            throw new ArgumentException($"Circular parameter reference detected: ${paramName}");
+        }
+
+        // If the value is another parameter reference, resolve recursively
+        if (value.StartsWith('$'))
+        {
+            var nestedParamName = value[1..];
+            return ResolveParameter(nestedParamName, bindings, visited);
+        }
+
+        return value;
+    }
+}

--- a/tools/acir/SpiceEmitter.cs
+++ b/tools/acir/SpiceEmitter.cs
@@ -41,6 +41,8 @@ public static class SpiceEmitter
     /// <param name="circuit">The circuit to emit (must be EL level).</param>
     /// <param name="writer">Text writer for output.</param>
     /// <param name="deviceModelMap">Optional map of PDK device names to resolved model definitions.</param>
+    /// <param name="document">Optional ACIR document for resolving instance types.</param>
+    /// <param name="resolution">Optional attach resolution result for resolved net names.</param>
     /// <exception cref="InvalidOperationException">Thrown if circuit is not EL level.</exception>
     /// <remarks>
     /// Output format:
@@ -49,6 +51,7 @@ public static class SpiceEmitter
     /// .subckt CircuitName port1 port2 ... supply1 ... ground1 ...
     /// * Internal nets: net1, net2, ...
     /// M... (device instances)
+    /// X... (circuit instances)
     /// .ends CircuitName
     /// </code>
     /// Port ordering: declared ports, then supplies, then grounds.
@@ -56,7 +59,9 @@ public static class SpiceEmitter
     public static void EmitDesign(
         Circuit circuit,
         TextWriter writer,
-        IReadOnlyDictionary<string, DeviceModelResolution>? deviceModelMap = null
+        IReadOnlyDictionary<string, DeviceModelResolution>? deviceModelMap = null,
+        ACIRDocument? document = null,
+        CircuitResolutionResult? resolution = null
     )
     {
         if (circuit.Level != ACIRLevel.EL)
@@ -104,6 +109,50 @@ public static class SpiceEmitter
             foreach (var device in circuit.Fill.Devices.OrderBy(d => d.Id, StringComparer.Ordinal))
             {
                 EmitDevice(device, writer, deviceModelMap);
+            }
+        }
+
+        // Emit circuit instances as X-elements or inline expansion
+        if (circuit.Fill?.Instances.Count > 0 && document is not null)
+        {
+            var circuitsByName = document.Circuits.ToDictionary(
+                c => c.Name,
+                StringComparer.Ordinal
+            );
+
+            bool hasEmittedCircuitInstancesHeader = false;
+
+            foreach (
+                var instance in circuit.Fill.Instances.OrderBy(i => i.Id, StringComparer.Ordinal)
+            )
+            {
+                if (circuitsByName.TryGetValue(instance.Type, out var targetCircuit))
+                {
+                    if (targetCircuit.Inline)
+                    {
+                        // Inline expansion: embed devices with hierarchical naming
+                        writer.WriteLine();
+                        writer.WriteLine($"* Inline expansion of {instance.Id} : {instance.Type}");
+                        ExpandInlineCircuit(
+                            instance,
+                            targetCircuit,
+                            resolution,
+                            deviceModelMap,
+                            writer
+                        );
+                    }
+                    else
+                    {
+                        // Non-inline: emit as X-element
+                        if (!hasEmittedCircuitInstancesHeader)
+                        {
+                            writer.WriteLine();
+                            writer.WriteLine("* Circuit instances");
+                            hasEmittedCircuitInstancesHeader = true;
+                        }
+                        EmitInstance(instance, targetCircuit, resolution, writer);
+                    }
+                }
             }
         }
 
@@ -188,10 +237,11 @@ public static class SpiceEmitter
     /// <returns>Result containing paths to generated files.</returns>
     /// <remarks>
     /// Processes all EL-level circuits in the document:
-    /// - Generates {CircuitName}.sp for each circuit
+    /// - Generates {CircuitName}.sp for each circuit in dependency order
     /// - Generates {CircuitName}_{BenchName}.sp for each bench using templates
     /// Output directory is created if it doesn't exist.
     /// Non-EL circuits are silently skipped.
+    /// Dependency order ensures .subckt definitions appear before X-element references.
     /// </remarks>
     public static SpiceEmitResult Emit(
         ACIRDocument doc,
@@ -207,7 +257,14 @@ public static class SpiceEmitter
         var result = new SpiceEmitResult();
         Directory.CreateDirectory(outputDir);
 
-        foreach (var circuit in doc.Circuits)
+        // Resolve attach statements for net connectivity
+        var attachResolver = new AttachResolver(doc);
+        var attachResult = attachResolver.Resolve();
+
+        // Order circuits by dependency (leaves first, top-level last)
+        var orderedCircuits = OrderByDependency(doc);
+
+        foreach (var circuit in orderedCircuits)
         {
             if (circuit.Level != ACIRLevel.EL)
             {
@@ -215,12 +272,19 @@ public static class SpiceEmitter
             }
 
             var includeResolution = includeResolver?.Resolve(circuit, backend);
+            var circuitResolution = attachResult.CircuitResults.GetValueOrDefault(circuit.Name);
 
             // Emit design netlist
             var designPath = Path.Combine(outputDir, $"{circuit.Name}.sp");
             using (var writer = File.CreateText(designPath))
             {
-                EmitDesign(circuit, writer, includeResolution?.DeviceModelMap);
+                EmitDesign(
+                    circuit,
+                    writer,
+                    includeResolution?.DeviceModelMap,
+                    doc,
+                    circuitResolution
+                );
             }
             result.DesignPaths.Add(designPath);
 
@@ -254,7 +318,7 @@ public static class SpiceEmitter
     /// <param name="workspaceRoot">Optional workspace root for template discovery.</param>
     /// <returns>Result containing paths to generated files and validation result.</returns>
     /// <remarks>
-    /// Runs emission validation before attempting SPICE generation.
+    /// Runs hierarchy validation and emission validation before attempting SPICE generation.
     /// If validation fails, no files are written and the validation errors are returned.
     /// </remarks>
     public static ValidatedEmitResult ValidateAndEmit(
@@ -270,7 +334,11 @@ public static class SpiceEmitter
 
         var validationResult = new ValidationResult();
 
-        // Validate all EL circuits first
+        // Validate hierarchy first (circuit references, parameters, ports, cycles)
+        var hierarchyValidation = HierarchyValidator.Validate(doc);
+        validationResult.Merge(hierarchyValidation);
+
+        // Validate all EL circuits for emission requirements
         var elCircuits = doc.Circuits.Where(c => c.Level == ACIRLevel.EL).ToList();
         foreach (var circuit in elCircuits)
         {
@@ -292,6 +360,97 @@ public static class SpiceEmitter
         var emitResult = Emit(doc, outputDir, backend, workspaceRoot, includeResolver);
 
         return new ValidatedEmitResult { Validation = validationResult, Emit = emitResult };
+    }
+
+    /// <summary>
+    /// Orders circuits by dependency using topological sort.
+    /// </summary>
+    /// <param name="doc">The ACIR document.</param>
+    /// <returns>Circuits ordered with leaf circuits first, top-level last.</returns>
+    /// <remarks>
+    /// Required for SPICE: .subckt must be defined before X-element reference.
+    /// Uses Kahn's algorithm for topological sort.
+    /// </remarks>
+    private static List<Circuit> OrderByDependency(ACIRDocument doc)
+    {
+        var circuits = doc.Circuits;
+        var circuitsByName = circuits.ToDictionary(c => c.Name, StringComparer.Ordinal);
+
+        // Build dependency graph: circuit -> circuits it depends on (instantiates)
+        var dependencies = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        foreach (var circuit in circuits)
+        {
+            dependencies[circuit.Name] = new HashSet<string>(StringComparer.Ordinal);
+            if (circuit.Fill?.Instances is not null)
+            {
+                foreach (var instance in circuit.Fill.Instances)
+                {
+                    // Only add dependency if the type exists in document and is not inline
+                    if (circuitsByName.TryGetValue(instance.Type, out var target) && !target.Inline)
+                    {
+                        dependencies[circuit.Name].Add(instance.Type);
+                    }
+                }
+            }
+        }
+
+        // Compute in-degrees (how many circuits depend on each circuit)
+        var inDegree = new Dictionary<string, int>(StringComparer.Ordinal);
+        foreach (var circuit in circuits)
+        {
+            inDegree[circuit.Name] = 0;
+        }
+        foreach (var deps in dependencies.Values)
+        {
+            foreach (var dep in deps)
+            {
+                if (inDegree.ContainsKey(dep))
+                {
+                    inDegree[dep]++;
+                }
+            }
+        }
+
+        // Kahn's algorithm: start with nodes that have no dependents
+        var queue = new Queue<string>();
+        foreach (var circuit in circuits)
+        {
+            if (inDegree[circuit.Name] == 0)
+            {
+                queue.Enqueue(circuit.Name);
+            }
+        }
+
+        var result = new List<Circuit>();
+        while (queue.Count > 0)
+        {
+            var name = queue.Dequeue();
+            result.Add(circuitsByName[name]);
+
+            // Reduce in-degree for circuits this one depends on
+            foreach (var dep in dependencies[name])
+            {
+                if (inDegree.ContainsKey(dep))
+                {
+                    inDegree[dep]--;
+                    if (inDegree[dep] == 0)
+                    {
+                        queue.Enqueue(dep);
+                    }
+                }
+            }
+        }
+
+        // If not all circuits were processed, there's a cycle (already caught by HierarchyValidator)
+        // Just return circuits in original order as fallback
+        if (result.Count < circuits.Count)
+        {
+            return circuits;
+        }
+
+        // Reverse to get dependency order (leaves first)
+        result.Reverse();
+        return result;
     }
 
     /// <summary>
@@ -361,6 +520,412 @@ public static class SpiceEmitter
         }
 
         writer.WriteLine(sb.ToString().TrimEnd());
+    }
+
+    /// <summary>
+    /// Emits a circuit instance as a SPICE X-element.
+    /// </summary>
+    /// <param name="instance">Instance declaration.</param>
+    /// <param name="targetCircuit">The circuit being instantiated.</param>
+    /// <param name="resolution">Optional attach resolution for net name mapping.</param>
+    /// <param name="writer">Text writer for output.</param>
+    /// <remarks>
+    /// Output format: X{id} {port1} {port2} ... {supply1} ... {ground1} ... {subckt_name}
+    /// Port ordering matches subcircuit declaration: ports, supplies, grounds.
+    /// </remarks>
+    private static void EmitInstance(
+        InstanceDeclaration instance,
+        Circuit targetCircuit,
+        CircuitResolutionResult? resolution,
+        TextWriter writer
+    )
+    {
+        var sb = new StringBuilder();
+        sb.Append('X');
+        sb.Append(instance.Id);
+        sb.Append(' ');
+
+        // Build port order: ports, supplies, grounds (matching subcircuit declaration)
+        var portOrder = new List<string>();
+        foreach (var port in targetCircuit.Ports)
+        {
+            portOrder.Add(port.Name);
+        }
+        foreach (var supply in targetCircuit.Supplies)
+        {
+            portOrder.Add(supply);
+        }
+        foreach (var ground in targetCircuit.Grounds)
+        {
+            portOrder.Add(ground);
+        }
+
+        // Emit port bindings in order
+        foreach (var portName in portOrder)
+        {
+            string netName;
+            if (instance.Bindings.TryGetValue(portName, out var boundNet))
+            {
+                // Use resolved net name if available
+                netName =
+                    resolution?.NetToRepresentative.GetValueOrDefault(boundNet, boundNet)
+                    ?? boundNet;
+            }
+            else if (
+                resolution?.TerminalToNet.TryGetValue(
+                    $"{instance.Id}.{portName}",
+                    out var resolvedNet
+                ) == true
+            )
+            {
+                netName = resolvedNet;
+            }
+            else
+            {
+                // Port not bound - use the port name itself (may be auto-connected)
+                netName = portName;
+            }
+            sb.Append(netName);
+            sb.Append(' ');
+        }
+
+        // Subcircuit name
+        sb.Append(targetCircuit.Name);
+
+        writer.WriteLine(sb.ToString().TrimEnd());
+    }
+
+    /// <summary>
+    /// Expands an inline circuit by embedding its devices with hierarchical naming.
+    /// </summary>
+    /// <param name="instance">Instance declaration being expanded.</param>
+    /// <param name="inlineCircuit">The inline circuit to expand.</param>
+    /// <param name="resolution">Optional attach resolution for net name mapping.</param>
+    /// <param name="deviceModelMap">Optional device model resolution map.</param>
+    /// <param name="writer">Text writer for output.</param>
+    /// <remarks>
+    /// Naming conventions:
+    /// - Device IDs: {instanceId}__{deviceId} (e.g., dp__M_N becomes M_dp__M_N)
+    /// - Internal nets: {instanceId}__{netId}
+    /// - Port bindings: substituted with parent-level nets
+    /// </remarks>
+    private static void ExpandInlineCircuit(
+        InstanceDeclaration instance,
+        Circuit inlineCircuit,
+        CircuitResolutionResult? resolution,
+        IReadOnlyDictionary<string, DeviceModelResolution>? deviceModelMap,
+        TextWriter writer
+    )
+    {
+        // Build port-to-net substitution map
+        var netSubstitutions = BuildNetSubstitutions(instance, inlineCircuit, resolution);
+
+        // Build set of internal nets (not ports, supplies, or grounds)
+        var internalNets = new HashSet<string>(StringComparer.Ordinal);
+        if (inlineCircuit.Fill?.Nets is not null)
+        {
+            foreach (var net in inlineCircuit.Fill.Nets)
+            {
+                internalNets.Add(net.Id);
+            }
+        }
+
+        // Emit devices with hierarchical naming
+        if (inlineCircuit.Fill?.Devices is not null)
+        {
+            foreach (
+                var device in inlineCircuit.Fill.Devices.OrderBy(d => d.Id, StringComparer.Ordinal)
+            )
+            {
+                EmitInlineDevice(
+                    device,
+                    instance.Id,
+                    netSubstitutions,
+                    internalNets,
+                    resolution,
+                    deviceModelMap,
+                    writer
+                );
+            }
+        }
+    }
+
+    /// <summary>
+    /// Builds net name substitution map for inline expansion.
+    /// </summary>
+    private static Dictionary<string, string> BuildNetSubstitutions(
+        InstanceDeclaration instance,
+        Circuit inlineCircuit,
+        CircuitResolutionResult? resolution
+    )
+    {
+        var substitutions = new Dictionary<string, string>(StringComparer.Ordinal);
+
+        // Map port names to bound nets
+        ResolveBindings(
+            inlineCircuit.Ports.Select(p => p.Name),
+            instance,
+            resolution,
+            substitutions
+        );
+
+        // Map supplies to bound nets
+        ResolveBindings(inlineCircuit.Supplies, instance, resolution, substitutions);
+
+        // Map grounds to bound nets
+        ResolveBindings(inlineCircuit.Grounds, instance, resolution, substitutions);
+
+        return substitutions;
+    }
+
+    /// <summary>
+    /// Resolves bindings for a collection of names and adds them to the substitutions map.
+    /// </summary>
+    private static void ResolveBindings(
+        IEnumerable<string> names,
+        InstanceDeclaration instance,
+        CircuitResolutionResult? resolution,
+        Dictionary<string, string> substitutions
+    )
+    {
+        foreach (var name in names)
+        {
+            if (instance.Bindings.TryGetValue(name, out var boundNet))
+            {
+                substitutions[name] =
+                    resolution?.NetToRepresentative.GetValueOrDefault(boundNet, boundNet)
+                    ?? boundNet;
+            }
+            else if (
+                resolution?.TerminalToNet.TryGetValue($"{instance.Id}.{name}", out var resolvedNet)
+                == true
+            )
+            {
+                substitutions[name] = resolvedNet;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Emits a device from an inline circuit with hierarchical naming.
+    /// </summary>
+    private static void EmitInlineDevice(
+        DeviceDeclaration device,
+        string instanceId,
+        Dictionary<string, string> netSubstitutions,
+        HashSet<string> internalNets,
+        CircuitResolutionResult? resolution,
+        IReadOnlyDictionary<string, DeviceModelResolution>? deviceModelMap,
+        TextWriter writer
+    )
+    {
+        var resolvedModel = ResolveDeviceModel(device, deviceModelMap);
+        var useSubckt = resolvedModel?.IsSubckt ?? false;
+
+        var spiceType = device.DeviceType.ToLowerInvariant() switch
+        {
+            "nmos" or "pmos" => useSubckt ? "X" : "M",
+            "resistor" => "R",
+            "capacitor" => "C",
+            "inductor" => "L",
+            "diode" => "D",
+            _ => throw new InvalidOperationException($"Unknown device type: {device.DeviceType}"),
+        };
+
+        var sb = new StringBuilder();
+        sb.Append(spiceType);
+        sb.Append(instanceId);
+        sb.Append("__");
+        sb.Append(device.Id);
+        sb.Append(' ');
+
+        // Emit terminals with net substitution
+        if (spiceType is "M" or "X")
+        {
+            EmitInlineMosfetTerminalsAndParams(
+                device,
+                instanceId,
+                netSubstitutions,
+                internalNets,
+                resolution,
+                sb,
+                deviceModelMap,
+                useSubckt
+            );
+        }
+        else if (spiceType is "R" or "C" or "L")
+        {
+            // Two-terminal: P N
+            sb.Append(
+                SubstituteNet(
+                    GetBinding(device, "P"),
+                    instanceId,
+                    netSubstitutions,
+                    internalNets,
+                    resolution
+                )
+            );
+            sb.Append(' ');
+            sb.Append(
+                SubstituteNet(
+                    GetBinding(device, "N"),
+                    instanceId,
+                    netSubstitutions,
+                    internalNets,
+                    resolution
+                )
+            );
+            sb.Append(' ');
+
+            var valueKey = spiceType switch
+            {
+                "R" => "R",
+                "C" => "C",
+                "L" => "L",
+                _ => throw new InvalidOperationException(),
+            };
+            if (device.Params.TryGetValue(valueKey, out var value))
+            {
+                sb.Append(value);
+            }
+        }
+        else if (spiceType == "D")
+        {
+            // Diode: A K
+            sb.Append(
+                SubstituteNet(
+                    GetBinding(device, "A"),
+                    instanceId,
+                    netSubstitutions,
+                    internalNets,
+                    resolution
+                )
+            );
+            sb.Append(' ');
+            sb.Append(
+                SubstituteNet(
+                    GetBinding(device, "K"),
+                    instanceId,
+                    netSubstitutions,
+                    internalNets,
+                    resolution
+                )
+            );
+            sb.Append(' ');
+            sb.Append(ResolveDeviceModelName(device, deviceModelMap, defaultModel: "D"));
+        }
+
+        writer.WriteLine(sb.ToString().TrimEnd());
+    }
+
+    /// <summary>
+    /// Emits MOSFET terminals and params for inline expansion.
+    /// </summary>
+    private static void EmitInlineMosfetTerminalsAndParams(
+        DeviceDeclaration device,
+        string instanceId,
+        Dictionary<string, string> netSubstitutions,
+        HashSet<string> internalNets,
+        CircuitResolutionResult? resolution,
+        StringBuilder sb,
+        IReadOnlyDictionary<string, DeviceModelResolution>? deviceModelMap,
+        bool useSubckt
+    )
+    {
+        // MOSFET terminal ordering: D G S B
+        sb.Append(
+            SubstituteNet(
+                GetBinding(device, "D"),
+                instanceId,
+                netSubstitutions,
+                internalNets,
+                resolution
+            )
+        );
+        sb.Append(' ');
+        sb.Append(
+            SubstituteNet(
+                GetBinding(device, "G"),
+                instanceId,
+                netSubstitutions,
+                internalNets,
+                resolution
+            )
+        );
+        sb.Append(' ');
+        sb.Append(
+            SubstituteNet(
+                GetBinding(device, "S"),
+                instanceId,
+                netSubstitutions,
+                internalNets,
+                resolution
+            )
+        );
+        sb.Append(' ');
+        sb.Append(
+            SubstituteNet(
+                GetBinding(device, "B"),
+                instanceId,
+                netSubstitutions,
+                internalNets,
+                resolution
+            )
+        );
+        sb.Append(' ');
+
+        // Model name
+        sb.Append(ResolveDeviceModelName(device, deviceModelMap, defaultModel: device.DeviceType));
+        sb.Append(' ');
+
+        // Parameters: W, L, m
+        if (device.Params.TryGetValue("W", out var w))
+        {
+            sb.Append(useSubckt ? $"w={w} " : $"W={w} ");
+        }
+        if (device.Params.TryGetValue("L", out var l))
+        {
+            sb.Append(useSubckt ? $"l={l} " : $"L={l} ");
+        }
+        if (device.Params.TryGetValue("M", out var m))
+        {
+            sb.Append(useSubckt ? $"mult={m}" : $"m={m}");
+        }
+    }
+
+    /// <summary>
+    /// Substitutes a net name for inline expansion.
+    /// </summary>
+    /// <param name="netName">Original net name from inline circuit.</param>
+    /// <param name="instanceId">Instance ID for hierarchical prefix.</param>
+    /// <param name="substitutions">Port/supply/ground substitution map.</param>
+    /// <param name="internalNets">Set of internal net names in the inline circuit.</param>
+    /// <param name="resolution">Optional attach resolution.</param>
+    /// <returns>Substituted net name.</returns>
+    private static string SubstituteNet(
+        string netName,
+        string instanceId,
+        Dictionary<string, string> substitutions,
+        HashSet<string> internalNets,
+        CircuitResolutionResult? resolution
+    )
+    {
+        // Check if this is a port/supply/ground that should be substituted
+        if (substitutions.TryGetValue(netName, out var boundNet))
+        {
+            // Use resolved net name if available
+            return resolution?.NetToRepresentative.GetValueOrDefault(boundNet, boundNet)
+                ?? boundNet;
+        }
+
+        // Internal net: prefix with instance ID
+        if (internalNets.Contains(netName))
+        {
+            return $"{instanceId}__{netName}";
+        }
+
+        // Unknown net - pass through (shouldn't happen in valid circuits)
+        return netName;
     }
 
     /// <summary>

--- a/tools/acir/UnionFind.cs
+++ b/tools/acir/UnionFind.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+
+namespace Cascode.ACIR;
+
+/// <summary>
+/// Union-find data structure for net connectivity.
+/// </summary>
+internal sealed class UnionFind<T>
+    where T : notnull
+{
+    private readonly Dictionary<T, T> _parent = new();
+    private readonly Dictionary<T, int> _rank = new();
+
+    public void MakeSet(T item)
+    {
+        if (_parent.ContainsKey(item))
+        {
+            return;
+        }
+
+        _parent[item] = item;
+        _rank[item] = 0;
+    }
+
+    public bool Contains(T item) => _parent.ContainsKey(item);
+
+    public T Find(T item)
+    {
+        if (!_parent.TryGetValue(item, out var parent))
+        {
+            throw new ArgumentException($"Item '{item}' not in union-find");
+        }
+
+        if (!EqualityComparer<T>.Default.Equals(parent, item))
+        {
+            _parent[item] = Find(parent); // Path compression
+        }
+
+        return _parent[item];
+    }
+
+    public void Union(T a, T b)
+    {
+        var rootA = Find(a);
+        var rootB = Find(b);
+
+        if (EqualityComparer<T>.Default.Equals(rootA, rootB))
+        {
+            return;
+        }
+
+        // Union by rank
+        if (_rank[rootA] < _rank[rootB])
+        {
+            _parent[rootA] = rootB;
+        }
+        else if (_rank[rootA] > _rank[rootB])
+        {
+            _parent[rootB] = rootA;
+        }
+        else
+        {
+            _parent[rootB] = rootA;
+            _rank[rootA]++;
+        }
+    }
+
+    public IEnumerable<T> GetAllElements() => _parent.Keys;
+}

--- a/tools/acir/Validation/HierarchyValidator.cs
+++ b/tools/acir/Validation/HierarchyValidator.cs
@@ -200,13 +200,6 @@ public static class HierarchyValidator
         {
             foreach (var attach in parentCircuit.Fill.Attaches)
             {
-                // Check if this attach involves our instance
-                if (attach.SourceInstance != instance.Id && attach.TargetInstance != instance.Id)
-                {
-                    continue;
-                }
-
-                // Find the connector and determine which ports are covered
                 var coveredPorts = GetPortsCoveredByAttach(attach, instance, targetCircuit, traits);
                 foreach (var port in coveredPorts)
                 {
@@ -267,23 +260,41 @@ public static class HierarchyValidator
             return coveredPorts;
         }
 
-        // Determine if this instance is source or target in the attach
-        if (attach.SourceInstance == instance.Id)
+        var instanceChain = new List<string> { attach.SourceInstance };
+        instanceChain.AddRange(attach.TargetInstances);
+
+        for (var pairIndex = 0; pairIndex < instanceChain.Count - 1; pairIndex++)
         {
-            // Instance is source - connector source ports are covered
+            var fromInstance = instanceChain[pairIndex];
+            var toInstance = instanceChain[pairIndex + 1];
+
             foreach (var mapping in connector.Mappings)
             {
-                var portName = mapping.SourcePort.Split('.')[0];
-                coveredPorts.Add(portName);
-            }
-        }
-        else if (attach.TargetInstance == instance.Id)
-        {
-            // Instance is target - connector target ports are covered
-            foreach (var mapping in connector.Mappings)
-            {
-                var portName = mapping.TargetPort.Split('.')[0];
-                coveredPorts.Add(portName);
+                var sourcePort = mapping.SourcePort;
+                var targetPort = mapping.TargetPort;
+
+                if (attach.Overrides is not null)
+                {
+                    var overrideMapping = attach.Overrides.FirstOrDefault(o =>
+                        o.SourcePort == sourcePort
+                    );
+                    if (overrideMapping is not null)
+                    {
+                        targetPort = overrideMapping.TargetPort;
+                    }
+                }
+
+                if (fromInstance == instance.Id)
+                {
+                    var portName = sourcePort.Split('.')[0];
+                    coveredPorts.Add(portName);
+                }
+
+                if (toInstance == instance.Id)
+                {
+                    var portName = targetPort.Split('.')[0];
+                    coveredPorts.Add(portName);
+                }
             }
         }
 
@@ -306,28 +317,38 @@ public static class HierarchyValidator
 
         foreach (var attach in circuit.Fill.Attaches)
         {
+            var attachChain = FormatAttachChain(attach);
             // HIER-006: Validate source instance exists
             if (!instanceIds.Contains(attach.SourceInstance))
             {
                 result.AddError(
                     "HIER-006",
                     $"Attach references unknown instance '{attach.SourceInstance}'",
-                    $"circuit {circuit.Name}, attach {attach.SourceInstance} to {attach.TargetInstance}",
+                    $"circuit {circuit.Name}, attach {attachChain}",
                     $"Check instance name or add 'inst {attach.SourceInstance} : <type>' declaration"
                 );
             }
 
             // HIER-006: Validate target instance exists
-            if (!instanceIds.Contains(attach.TargetInstance))
+            foreach (var targetInstance in attach.TargetInstances)
             {
-                result.AddError(
-                    "HIER-006",
-                    $"Attach references unknown instance '{attach.TargetInstance}'",
-                    $"circuit {circuit.Name}, attach {attach.SourceInstance} to {attach.TargetInstance}",
-                    $"Check instance name or add 'inst {attach.TargetInstance} : <type>' declaration"
-                );
+                if (!instanceIds.Contains(targetInstance))
+                {
+                    result.AddError(
+                        "HIER-006",
+                        $"Attach references unknown instance '{targetInstance}'",
+                        $"circuit {circuit.Name}, attach {attachChain}",
+                        $"Check instance name or add 'inst {targetInstance} : <type>' declaration"
+                    );
+                }
             }
         }
+    }
+
+    private static string FormatAttachChain(AttachStatement attach)
+    {
+        var instanceChain = AttachResolver.BuildInstanceChain(attach);
+        return string.Join(" to ", instanceChain);
     }
 
     /// <summary>

--- a/tools/cli/Commands/ConvertCommandModule.cs
+++ b/tools/cli/Commands/ConvertCommandModule.cs
@@ -153,24 +153,20 @@ internal sealed class ConvertCommandModule : ICommandModule
             return new CommandResult(2, false);
         }
 
-        ACIRDocument doc;
-        try
+        var result = AcirJsonConverter.FromJson(json, inputPath);
+
+        if (!result.Success)
         {
-            doc = AcirJsonConverter.FromJson(json);
-        }
-        catch (Exception ex)
-        {
-            _state.AddMessage($"Failed to parse JSON: {ex.Message}");
+            foreach (
+                var diag in result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)
+            )
+            {
+                _state.AddMessage($"{diag.FilePath}:{diag.Line}: {diag.Message}");
+            }
             return new CommandResult(2, false);
         }
 
-        if (doc.VersionMajor != ACIRVersion.Major)
-        {
-            _state.AddMessage(
-                $"ACIR major version {doc.VersionMajor} not supported. Expected major version {ACIRVersion.Major}."
-            );
-            return new CommandResult(2, false);
-        }
+        var doc = result.Document!;
 
         using var writer = new StringWriter();
         ACIRWriter.Write(doc, writer);


### PR DESCRIPTION
Continuation of the ACIR 2.0 PR stack

Validates hierarchical ACIR documents before SPICE emission:
- HIER-001: Undefined circuit reference in instance type
- HIER-002: Missing required parameter at instantiation
- HIER-003: Uncovered instance port (binding or attach required)
- HIER-004: Circular instantiation dependency via DFS
- HIER-006: Unknown instance in attach statement

Port coverage validation considers:
- Direct terminal bindings (PORT -> net)
- Attach statement coverage via connector mappings
- Bundle notation handling (IN.P covers port IN)

Uses dependency graph construction and DFS for cycle detection.
Integrates with ValidationResult for structured error reporting.