### PR TITLE
[bench] Support spot gain measurement

### DIFF
--- a/docs/language/bench-cookbook.md
+++ b/docs/language/bench-cookbook.md
@@ -45,6 +45,18 @@ Frequency f10 = G.Range(to=1MHz, from=100Hz).ValueAt(f=10kHz)
 Time tclk = period(f=1MHz)
 ```
 
+Standard transfer benches also expose both spot and band gain measurements:
+
+```cascode
+measurement Gain(Frequency f) : dB {
+  return db20(transfer(ac, IN, OUT).Mag()).ValueAt(f)
+}
+
+measurement Gain(Frequency from, Frequency to) : dB {
+  return db20(transfer(ac, IN, OUT).Mag()).From(from).To(to)
+}
+```
+
 Reference implementations live in [`lib/std/bench/TransferBenches.cas`](../../lib/std/bench/TransferBenches.cas):
 
 - `DiffToSETransfer` (Diff → analog)

--- a/docs/rfcs/0000-acir-measurement-abstraction.md
+++ b/docs/rfcs/0000-acir-measurement-abstraction.md
@@ -542,6 +542,18 @@ The `measurements {}` block defines typed measurement expressions:
 
 ```cascode
 measurements {
+  measurement Gain(Frequency f) : dB {
+    TransferFunction H = transfer(ac, IN, OUT)
+    GainSpectrum G = db20(H.Mag())
+    return G.ValueAt(f)
+  }
+
+  measurement Gain(Frequency from, Frequency to) : dB {
+    TransferFunction H = transfer(ac, IN, OUT)
+    GainSpectrum G = db20(H.Mag())
+    return G.From(from).To(to)
+  }
+
   measurement PassbandGain : dB {
     TransferFunction H = transfer(ac, IN, OUT)
     GainSpectrum G = db20(H.Mag())
@@ -600,7 +612,7 @@ measurement IntegratedInputNoise(Frequency from, Frequency to) : nVrms {
 
 **Invocation syntax (explicit call syntax always):**
 - Non-parameterized: `LowpassBandwidth()` (parentheses required)
-- Parameterized: `IntegratedInputNoise(from=1Hz, to=10MHz)` (named arguments)
+- Parameterized: `IntegratedInputNoise(from=1Hz, to=10MHz)` or `Gain(f=1MHz)` (named arguments)
 
 **In constraints:**
 ```cascode
@@ -911,6 +923,18 @@ bench DiffToSETransfer {
   }
 
   measurements {
+    measurement Gain(Frequency f) : dB {
+      TransferFunction H = transfer(ac, IN, OUT)
+      GainSpectrum G = db20(H.Mag())
+      return G.ValueAt(f)
+    }
+
+    measurement Gain(Frequency from, Frequency to) : dB {
+      TransferFunction H = transfer(ac, IN, OUT)
+      GainSpectrum G = db20(H.Mag())
+      return G.From(from).To(to)
+    }
+
     measurement PassbandGain : dB {
       TransferFunction H = transfer(ac, IN, OUT)
       GainSpectrum G = db20(H.Mag())

--- a/docs/rfcs/0004-abstract-benches.md
+++ b/docs/rfcs/0004-abstract-benches.md
@@ -20,11 +20,11 @@ This RFC proposes an `abstract bench` mechanism that allows bench families to sh
 `lib/std/bench/TransferBenches.cas` defines five benches in 411 lines. Three of them — `DiffToSETransfer`, `DiffToDiffTransfer`, and `SEToSETransfer` — share the same structure:
 
 - Identical `analysis` blocks (an `ACAnalysis` with constraint-driven start/stop)
-- Identical `measurements` blocks (six measurements: `PassbandGain`, `GainBandwidth`, `PhaseMargin`, `LowpassBandwidth`, `HighpassBandwidth`, `BandpassBandwidth`)
+- Identical `measurements` blocks (seven declarations: `Gain`, `PassbandGain`, `GainBandwidth`, `PhaseMargin`, `LowpassBandwidth`, `HighpassBandwidth`, `BandpassBandwidth`)
 - Different `stim`/`resp` terminal type declarations
 - Different `fill` blocks that construct topology-appropriate stimulus and load circuits
 
-The analysis and measurement blocks are copied verbatim across all three benches. The only variation within measurements is that each bench passes its own `IN` and `OUT` terminals to the shared file-level helpers (`calc_passband_gain`, `calc_gain_bandwidth`, etc.). This is exactly the kind of reference that abstract terminals would resolve: the measurement expressions reference terminal names, and the extending bench provides the concrete typed terminals.
+The analysis and measurement blocks are copied verbatim across all three benches. The only variation within measurements is that each bench passes its own `IN` and `OUT` terminals either to the shared file-level helpers (`calc_passband_gain`, `calc_gain_bandwidth`, etc.) or directly to `transfer(ac, IN, OUT)` for spot and band gain. This is exactly the kind of reference that abstract terminals would resolve: the measurement expressions reference terminal names, and the extending bench provides the concrete typed terminals.
 
 Similarly, the two CM rejection benches (`DiffCMRejection` and `DiffToSECMRejection`) share identical analysis and measurement blocks but differ in terminal types and fill topology.
 
@@ -70,6 +70,14 @@ abstract bench AbstractTransfer {
   }
 
   measurements {
+    measurement Gain(Frequency f) : dB {
+      return db20(transfer(ac, IN, OUT).Mag()).ValueAt(f)
+    }
+
+    measurement Gain(Frequency from, Frequency to) : dB {
+      return db20(transfer(ac, IN, OUT).Mag()).From(from).To(to)
+    }
+
     measurement PassbandGain : dB {
       return calc_passband_gain(ac, IN, OUT, constraints.LowpassBandwidth, constraints.GainBandwidth)
     }
@@ -384,6 +392,14 @@ abstract bench AbstractTransfer {
   }
 
   measurements {
+    measurement Gain(Frequency f) : dB {
+      return db20(transfer(ac, IN, OUT).Mag()).ValueAt(f)
+    }
+
+    measurement Gain(Frequency from, Frequency to) : dB {
+      return db20(transfer(ac, IN, OUT).Mag()).From(from).To(to)
+    }
+
     measurement PassbandGain : dB {
       return calc_passband_gain(ac, IN, OUT, constraints.LowpassBandwidth, constraints.GainBandwidth)
     }

--- a/lib/std/bench/TransferBenches.cas
+++ b/lib/std/bench/TransferBenches.cas
@@ -97,6 +97,10 @@ abstract bench AbstractTransfer {
   }
 
   measurements {
+    measurement Gain(Frequency f) : dB {
+      return db20(transfer(ac, IN, OUT).Mag()).ValueAt(f)
+    }
+
     measurement Gain(Frequency from, Frequency to) : dB {
       return db20(transfer(ac, IN, OUT).Mag()).From(from).To(to)
     }

--- a/spec/language/Ch04_Bench_System.md
+++ b/spec/language/Ch04_Bench_System.md
@@ -503,6 +503,9 @@ measurements {
 }
 ```
 
+The standard transfer benches use the same arity-based overloading pattern for `Gain(f)` and
+`Gain(from, to)`.
+
 Declaring multiple measurements with the same name and the same parameter count is a semantic error.
 
 ---
@@ -788,6 +791,8 @@ constraints {
   numeric {
     c_gbw = transfer_bench::GainBandwidth at net::OUT >= 20MHz
     c_gain = transfer_bench::PassbandGain at net::OUT >= 40dB
+    c_gain_at_1mhz = transfer_bench::Gain(f=1MHz) at net::OUT >= 35dB
+    c_gain_band = transfer_bench::Gain(from=100kHz, to=10MHz) at net::OUT >= 30dB
     c_pm = transfer_bench::PhaseMargin at net::OUT >= 60deg
 
     c_int = noise_bench::IntegratedInputNoise(from=10Hz, to=10MHz) <= 1uVrms

--- a/tests/golden/cas/stress/CSAmp_ActiveLoad_Sky130.cas
+++ b/tests/golden/cas/stress/CSAmp_ActiveLoad_Sky130.cas
@@ -45,6 +45,7 @@ circuit CSAmp_ActiveLoad_Sky130 implements SingleEndedAmp {
     numeric {
       c_gbw = transfer_bench::GainBandwidth at net::OUT >= 5MHz
       c_gain = transfer_bench::PassbandGain at net::OUT >= 15dB
+      c_gain_at_100kHz = transfer_bench::Gain(f=100kHz) at net::OUT >= 20dB
       c_gain_band = transfer_bench::Gain(from=100kHz, to=10MHz) at net::OUT >= 9dB
       c_int_noise = noise_bench::IntegratedInputNoise(from=10Hz, to=10MHz) <= 100uVrms
       c_vdd_pwr = vdd_pwr::QuiescentPower <= 10mW


### PR DESCRIPTION
Spot gain measurement is necessary for rolloff gain constraints in filter designs.  Currently, the following error happens:
```
I found the root cause: the built-in `SEToSETransfer` bench defaults to `1 Hz → 10 GHz` log sweep, so single-point `from=to` constraints at 1.44 MHz and 155 MHz miss sampled points and become “empty range.” I’m testing a legal override of that bench in `solution.cas` with a fixed sweep that includes both exact endpoints.
```